### PR TITLE
Add MockBukkit test utilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,17 @@
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
 		</dependency>
+
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<type>jar</type>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.7.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.seeseemelk</groupId>
+			<artifactId>MockBukkit-v1.16</artifactId>
+			<version>0.5.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/fr/zcraft/quartzlib/components/scoreboard/Sidebar.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/scoreboard/Sidebar.java
@@ -33,6 +33,8 @@ import com.google.common.collect.ImmutableSet;
 import fr.zcraft.quartzlib.components.scoreboard.sender.ObjectiveSender;
 import fr.zcraft.quartzlib.components.scoreboard.sender.SidebarObjective;
 import fr.zcraft.quartzlib.core.QuartzLib;
+import fr.zcraft.quartzlib.exceptions.IncompatibleMinecraftVersionException;
+import fr.zcraft.quartzlib.tools.PluginLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -633,7 +635,11 @@ public abstract class Sidebar
             sidebar.runAutoRefresh(false);
         }
 
-        ObjectiveSender.clearForAll();
+        try {
+            ObjectiveSender.clearForAll();
+        } catch (IncompatibleMinecraftVersionException e) {
+            PluginLogger.warning("Could not properly disable Sidebar", e);
+        }
     }
 
     /**

--- a/src/main/java/fr/zcraft/quartzlib/components/scoreboard/sender/ObjectiveSender.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/scoreboard/sender/ObjectiveSender.java
@@ -32,6 +32,7 @@ package fr.zcraft.quartzlib.components.scoreboard.sender;
 
 import fr.zcraft.quartzlib.components.scoreboard.Sidebar;
 import fr.zcraft.quartzlib.exceptions.IncompatibleMinecraftVersionException;
+import fr.zcraft.quartzlib.tools.PluginLogger;
 import fr.zcraft.quartzlib.tools.reflection.NMSNetwork;
 import fr.zcraft.quartzlib.tools.reflection.Reflection;
 import org.apache.commons.lang.Validate;
@@ -74,9 +75,9 @@ public class ObjectiveSender
 
 
     // The NMS classes & enum values needed to send the packets.
-    private final static Class<?> packetPlayOutScoreboardObjectiveClass;
-    private final static Class<?> packetPlayOutScoreboardDisplayObjectiveClass;
-    private final static Class<?> packetPlayOutScoreboardScoreClass;
+    private static Class<?> packetPlayOutScoreboardObjectiveClass;
+    private static Class<?> packetPlayOutScoreboardDisplayObjectiveClass;
+    private static Class<?> packetPlayOutScoreboardScoreClass;
     private static Class<?> chatComponentText;
 
     private static Object enumScoreboardHealthDisplay_INTEGER = null;
@@ -167,7 +168,7 @@ public class ObjectiveSender
         }
         catch (ClassNotFoundException e)
         {
-            throw new IncompatibleMinecraftVersionException("Unable to get the required classes to send scoreboard packets", e);
+            PluginLogger.warning("Unable to get the required classes to send scoreboard packets", e);
         }
     }
 

--- a/src/main/java/fr/zcraft/quartzlib/core/QuartzPlugin.java
+++ b/src/main/java/fr/zcraft/quartzlib/core/QuartzPlugin.java
@@ -30,8 +30,11 @@
 package fr.zcraft.quartzlib.core;
 
 import fr.zcraft.quartzlib.tools.PluginLogger;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.java.JavaPluginLoader;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.jar.JarFile;
 
@@ -45,6 +48,16 @@ import java.util.jar.JarFile;
  */
 public abstract class QuartzPlugin extends JavaPlugin
 {
+    protected QuartzPlugin()
+    {
+        super();
+    }
+
+    protected QuartzPlugin(JavaPluginLoader loader, PluginDescriptionFile description, File dataFolder, File file)
+    {
+        super(loader, description, dataFolder, file);
+    }
+
     @Override
     public void onLoad()
     {
@@ -80,7 +93,9 @@ public abstract class QuartzPlugin extends JavaPlugin
     {
         try
         {
-            return new JarFile(getFile());
+            File file = getFile();
+            if (file == null) return null;
+            return new JarFile(file);
         }
         catch (IOException e)
         {

--- a/src/main/java/fr/zcraft/quartzlib/tools/items/ItemStackBuilder.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/items/ItemStackBuilder.java
@@ -67,7 +67,7 @@ import java.util.Map.Entry;
  *                  .title(ChatColor.GOLD + "The best totem of all totems")
  *
  *                  .lore(ChatColor.GRAY + "I'm better than the others.")
- *                  .emptyLore()
+ *                  .loreSeparator()
  *
  *                  // This one will be automatically wrapped to 28-characters lines so
  *                  // the rendered tooltip is not too wide.
@@ -190,9 +190,10 @@ public class ItemStackBuilder
 
             ItemMeta meta = itemStack.getItemMeta();
 
-            if (meta != null && meta.getLore() != null)
+            if (meta != null && meta.hasLore())
             {
-                loreLines.addAll(meta.getLore());
+                List<String> lore = meta.getLore();
+                if (lore != null) loreLines.addAll(lore);
             }
         }
     }
@@ -418,8 +419,8 @@ public class ItemStackBuilder
     /**
      * Adds one line of lore to the ItemStack.
      *
-     * @param text The line of lore. If several are provided, they will be all
-     *             concatenated.
+     * @param text The line of lore. If several strings are provided, they will be all
+     *             concatenated into a single line.
      *
      * @return The current ItemStackBuilder instance, for methods chaining.
      */
@@ -432,8 +433,8 @@ public class ItemStackBuilder
      * Adds one line of lore to the ItemStack.
      *
      * @param color The color for this line of lore.
-     * @param text  The line of lore. If several are provided, they will be all
-     *              concatenated.
+     * @param text  The line of lore. If several strings are provided, they will be all
+     *              concatenated into a single line.
      *
      * @return The current ItemStackBuilder instance, for methods chaining.
      */
@@ -704,7 +705,7 @@ public class ItemStackBuilder
 
     /**
      * Sets the NBT data to replace the whole data in the item stack. If not called,
-     * NBT data will be appended to the existing data, overriding concurrent keys only.
+     * NBT data will be appended to the existing data, overriding conflicting keys only.
      * If this is called, the whole NBT data will be the data set in {@link #nbt(Map)},
      * clearing any existing data.
      *
@@ -726,7 +727,6 @@ public class ItemStackBuilder
      */
     private String arrayToString(String... texts)
     {
-
         StringBuilder builder = new StringBuilder();
 
         for (String text : texts)

--- a/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
@@ -6,6 +6,12 @@ import fr.zcraft.ztoaster.Toaster;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+/**
+ * A simple base class for tests that just set up a Mock Bukkit server, without any plugin associated.
+ *
+ * This is useful for testing simple, non-plugin-related APIs (such as ItemStack) that however require a Server to be
+ * instantiated.
+ */
 public abstract class MockedBukkitTest {
     protected ServerMock server;
 

--- a/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
@@ -3,21 +3,21 @@ package fr.zcraft.quartzlib;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import fr.zcraft.ztoaster.Toaster;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class MockedBukkitTest {
     protected ServerMock server;
     protected Toaster plugin;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(Toaster.class);
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
         MockBukkit.unmock();

--- a/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
@@ -20,6 +20,6 @@ public abstract class MockedBukkitTest {
     @After
     public void tearDown()
     {
-        MockBukkit.unload();
+        MockBukkit.unmock();
     }
 }

--- a/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
@@ -1,0 +1,25 @@
+package fr.zcraft.quartzlib;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import fr.zcraft.ztoaster.Toaster;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class MockedBukkitTest {
+    protected ServerMock server;
+    protected Toaster plugin;
+
+    @Before
+    public void setUp()
+    {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.load(Toaster.class);
+    }
+
+    @After
+    public void tearDown()
+    {
+        MockBukkit.unload();
+    }
+}

--- a/src/test/java/fr/zcraft/quartzlib/MockedToasterTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedToasterTest.java
@@ -6,13 +6,15 @@ import fr.zcraft.ztoaster.Toaster;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-public abstract class MockedBukkitTest {
+public abstract class MockedToasterTest {
     protected ServerMock server;
+    protected Toaster plugin;
 
     @BeforeEach
     public void setUp()
     {
         server = MockBukkit.mock();
+        plugin = MockBukkit.load(Toaster.class);
     }
 
     @AfterEach

--- a/src/test/java/fr/zcraft/quartzlib/MockedToasterTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedToasterTest.java
@@ -6,6 +6,9 @@ import fr.zcraft.ztoaster.Toaster;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+/**
+ * A base class for tests, that sets up a mock server and enables the Toaster plugin inside it.
+ */
 public abstract class MockedToasterTest {
     protected ServerMock server;
     protected Toaster plugin;

--- a/src/test/java/fr/zcraft/quartzlib/components/commands/CommandFlagsTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/components/commands/CommandFlagsTest.java
@@ -33,7 +33,7 @@ package fr.zcraft.quartzlib.components.commands;
 
 import junit.framework.Assert;
 import org.apache.commons.lang.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/src/test/java/fr/zcraft/quartzlib/components/gui/GuiUtilsTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/components/gui/GuiUtilsTest.java
@@ -34,7 +34,7 @@ package fr.zcraft.quartzlib.components.gui;
 import com.google.common.collect.Lists;
 import junit.framework.Assert;
 import org.apache.commons.lang.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 

--- a/src/test/java/fr/zcraft/quartzlib/components/rawtext/ChatColorParserTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/components/rawtext/ChatColorParserTest.java
@@ -35,7 +35,7 @@ import fr.zcraft.quartzlib.tools.text.ChatColoredString;
 import java.util.EnumSet;
 import org.bukkit.ChatColor;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChatColorParserTest 
 {

--- a/src/test/java/fr/zcraft/quartzlib/components/rawtext/RawTextTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/components/rawtext/RawTextTest.java
@@ -36,7 +36,7 @@ import org.bukkit.ChatColor;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
@@ -1,0 +1,13 @@
+package fr.zcraft.quartzlib.core;
+
+import fr.zcraft.quartzlib.MockedBukkitTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+public class QuartzLibTest extends MockedBukkitTest {
+    @Test
+    public void getPluginTest() {
+        assertSame(plugin, QuartzLib.getPlugin());
+    }
+}

--- a/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
@@ -1,11 +1,11 @@
 package fr.zcraft.quartzlib.core;
 
-import fr.zcraft.quartzlib.MockedBukkitTest;
+import fr.zcraft.quartzlib.MockedToasterTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertSame;
 
-public class QuartzLibTest extends MockedBukkitTest {
+public class QuartzLibTest extends MockedToasterTest {
     @Test
     public void getPluginTest() {
         assertSame(plugin, QuartzLib.getPlugin());

--- a/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
@@ -1,7 +1,7 @@
 package fr.zcraft.quartzlib.core;
 
 import fr.zcraft.quartzlib.MockedBukkitTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertSame;
 

--- a/src/test/java/fr/zcraft/quartzlib/i18n/POParserTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/i18n/POParserTest.java
@@ -75,8 +75,7 @@ public class POParserTest
     @Test
     public void testTranslationsCount()
     {
-        Assert.assertFalse("Translations from PO file missing", po.getTranslations().size() < 13);
-        Assert.assertFalse("Translations from PO file in a too high count", po.getTranslations().size() > 13);
+        Assert.assertEquals("Translations from PO file missing or are too many", po.getTranslations().size(), 20);
     }
 
     @Test
@@ -88,34 +87,34 @@ public class POParserTest
             {
                 case "{darkgreen}{bold}Cook":
                     Assert.assertEquals("Bad translations count for single translation", 1, translation.getTranslations().size());
-                    Assert.assertEquals("Bad translation", "{darkgreen}{bold}Cuisinier", translation.getTranslations().get(0));
+                    Assert.assertEquals("Bad translation", "{darkgreen}{bold}Cuistot", translation.getTranslations().get(0));
                     Assert.assertEquals("Bad context", "sidebar", translation.getContext());
                     break;
 
                 case "{red}{bold}♨ Toaster ♨":
                     Assert.assertEquals("Bad translations count for single translation with UTF-8", 1, translation.getTranslations().size());
-                    Assert.assertEquals("Bad translation with UTF-8", "{red}{bold}♨ Toaster ♨", translation.getTranslations().get(0));
+                    Assert.assertEquals("Bad translation with UTF-8", "{red}{bold}♨ Grille-pain ♨", translation.getTranslations().get(0));
                     Assert.assertEquals("Bad context with UTF-8 messageId", "sidebar", translation.getContext());
                     break;
 
                 case "One toast added.":
                     Assert.assertEquals("Bad translations count for translation with plural", 2, translation.getTranslations().size());
                     Assert.assertEquals("Bad extracted plural messageId", "{0} toasts added.", translation.getOriginalPlural());
-                    Assert.assertEquals("Bad singular translation", "Un toast ajouté.", translation.getTranslations().get(0));
-                    Assert.assertEquals("Bad plural translation", "{0} toasts ajoutés.", translation.getTranslations().get(1));
+                    Assert.assertEquals("Bad singular translation", "Un pain ajouté.", translation.getTranslations().get(0));
+                    Assert.assertEquals("Bad plural translation", "{0} pains ajoutés.", translation.getTranslations().get(1));
                     Assert.assertEquals("Bad null context with plurals", null, translation.getContext());
                     break;
 
                 case "There are no toasts here ...":
                     Assert.assertEquals("Bad translations count for single translation without context", 1, translation.getTranslations().size());
-                    Assert.assertEquals("Bad translation without context", "Il n'y a pas de toasts ici...", translation.getTranslations().get(0));
+                    Assert.assertEquals("Bad translation without context", "Il n'y a pas de pain grillé ici...", translation.getTranslations().get(0));
                     Assert.assertEquals("Bad null context", null, translation.getContext());
                     break;
 
                 case "  Toast #{0}":
                     Assert.assertEquals("Bad translations count for single translation with empty context", 1, translation.getTranslations().size());
-                    Assert.assertEquals("Bad translation with empty context", "  Toast no. {0}", translation.getTranslations().get(0));
-                    Assert.assertEquals("Bad empty context", "", translation.getContext());
+                    Assert.assertEquals("Bad translation with empty context", "  Pain grillé no. {0}", translation.getTranslations().get(0));
+                    Assert.assertEquals("Bad empty context", null, translation.getContext());
                     break;
 
                 case "It's just a \"toaster\"":

--- a/src/test/java/fr/zcraft/quartzlib/i18n/POParserTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/i18n/POParserTest.java
@@ -33,8 +33,8 @@ import fr.zcraft.quartzlib.TestsUtils;
 import fr.zcraft.quartzlib.components.i18n.translators.Translation;
 import fr.zcraft.quartzlib.components.i18n.translators.gettext.POFile;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.InputStreamReader;
 
@@ -44,7 +44,7 @@ public class POParserTest
     private final POFile po = new POFile(new InputStreamReader(TestsUtils.getResource("i18n/fr_FR.po")));
 
     @Test
-    @Before
+    @BeforeEach
     public void testPoParsing()
     {
         try

--- a/src/test/java/fr/zcraft/quartzlib/i18n/PoTranslatorTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/i18n/PoTranslatorTest.java
@@ -34,8 +34,8 @@ import fr.zcraft.quartzlib.components.i18n.translators.Translator;
 import fr.zcraft.quartzlib.components.i18n.translators.gettext.GettextPOTranslator;
 import fr.zcraft.quartzlib.tools.reflection.Reflection;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -61,7 +61,7 @@ public class PoTranslatorTest
     }
 
     @Test
-    @Before
+    @BeforeEach
     public void testTranslatorTypeFromFileName()
     {
         Assert.assertEquals("Translator instance badly loaded from file name", GettextPOTranslator.class, translator.getClass());

--- a/src/test/java/fr/zcraft/quartzlib/i18n/PoTranslatorTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/i18n/PoTranslatorTest.java
@@ -93,7 +93,7 @@ public class PoTranslatorTest
     @Test
     public void testBasicTranslations()
     {
-        Assert.assertEquals("Bad translation", "Il n'y a pas de toasts ici...", translator.translate(null, "There are no toasts here ...", null, null));
+        Assert.assertEquals("Bad translation", "Il n'y a pas de pain grillé ici...", translator.translate(null, "There are no toasts here ...", null, null));
     }
 
     @Test
@@ -107,15 +107,15 @@ public class PoTranslatorTest
     public void testContexts()
     {
         Assert.assertEquals("Bad translation with context", "{gold}{bold}Cuit", translator.translate("sidebar", "{gold}{bold}Cooked", null, null));
-        Assert.assertEquals("Bad translation with context and UTF-8", "{red}{bold}♨ Toaster ♨", translator.translate("sidebar", "{red}{bold}♨ Toaster ♨", null, null));
-        Assert.assertEquals("Bad translation with empty context", "  Toast no. {0}", translator.translate("", "  Toast #{0}", null, null));
+        Assert.assertEquals("Bad translation with context and UTF-8", "{red}{bold}♨ Grille-pain ♨", translator.translate("sidebar", "{red}{bold}♨ Toaster ♨", null, null));
+        Assert.assertEquals("Bad translation with empty context", null, translator.translate("", "  Toast #{0}", null, null));
     }
 
     @Test
     public void testPlurals()
     {
-        Assert.assertEquals("Bad translation with plural (singular)", "Un toast ajouté.", translator.translate(null, "One toast added.", "{0} toasts added.", 1));
-        Assert.assertEquals("Bad translation with plural (plural)", "{0} toasts ajoutés.", translator.translate(null, "One toast added.", "{0} toasts added.", 2));
+        Assert.assertEquals("Bad translation with plural (singular)", "Un pain ajouté.", translator.translate(null, "One toast added.", "{0} toasts added.", 1));
+        Assert.assertEquals("Bad translation with plural (plural)", "{0} pains ajoutés.", translator.translate(null, "One toast added.", "{0} toasts added.", 2));
     }
 
     @Test

--- a/src/test/java/fr/zcraft/quartzlib/i18n/PropertiesTranslatorTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/i18n/PropertiesTranslatorTest.java
@@ -34,8 +34,8 @@ import fr.zcraft.quartzlib.components.i18n.translators.Translator;
 import fr.zcraft.quartzlib.components.i18n.translators.properties.PropertiesTranslator;
 import fr.zcraft.quartzlib.tools.reflection.Reflection;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -61,7 +61,7 @@ public class PropertiesTranslatorTest
     }
 
     @Test
-    @Before
+    @BeforeEach
     public void testTranslatorTypeFromFileName()
     {
         Assert.assertEquals("Translator instance badly loaded from file name", PropertiesTranslator.class, translator.getClass());

--- a/src/test/java/fr/zcraft/quartzlib/i18n/YAMLTranslatorTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/i18n/YAMLTranslatorTest.java
@@ -35,7 +35,7 @@ import fr.zcraft.quartzlib.components.i18n.translators.yaml.YAMLTranslator;
 import fr.zcraft.quartzlib.tools.reflection.Reflection;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;

--- a/src/test/java/fr/zcraft/quartzlib/tools/items/ItemStackBuilderTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/tools/items/ItemStackBuilderTest.java
@@ -1,0 +1,136 @@
+package fr.zcraft.quartzlib.tools.items;
+
+import fr.zcraft.quartzlib.MockedBukkitTest;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+
+public class ItemStackBuilderTest extends MockedBukkitTest {
+    @Test
+    public void throwsOnEmptyBuilder () {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ItemStackBuilder().item(), "Material cannot be null");
+    }
+
+    @Test
+    public void buildsWithDefaultAmount () {
+        Assertions.assertEquals(1, new ItemStackBuilder(Material.QUARTZ).item().getAmount());
+    }
+
+    @Test
+    public void canBuildBasicItemStack () {
+        ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ, 42).item();
+
+        Assertions.assertEquals(Material.QUARTZ, itemStack.getType());
+        Assertions.assertEquals(42, itemStack.getAmount());
+    }
+
+    @Test
+    public void canEditExistingItemStack () {
+        ItemStack itemStack = new ItemStack(Material.QUARTZ, 42);
+        new ItemStackBuilder(itemStack).amount(50).item();
+
+        Assertions.assertEquals(Material.QUARTZ, itemStack.getType());
+        Assertions.assertEquals(50, itemStack.getAmount());
+
+        new ItemStackBuilder(itemStack).material(Material.DIORITE).item();
+
+        Assertions.assertEquals(Material.DIORITE, itemStack.getType());
+        Assertions.assertEquals(50, itemStack.getAmount());
+    }
+
+    @Test
+    public void noopsWhenEditingItemStackWithoutChanges () {
+        ItemStack itemStack = new ItemStack(Material.QUARTZ, 42);
+        ItemMeta itemMeta = Objects.requireNonNull(itemStack.getItemMeta());
+        itemMeta.setLore(Arrays.asList("foo", "bar"));
+        itemStack.setItemMeta(itemMeta);
+
+        new ItemStackBuilder(itemStack).item();
+
+        Assertions.assertEquals(Material.QUARTZ, itemStack.getType());
+        Assertions.assertEquals(42, itemStack.getAmount());
+        Assertions.assertEquals(Arrays.asList("foo", "bar"), itemStack.getItemMeta().getLore());
+    }
+
+    @Test
+    public void canSetDisplayName () {
+        ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ).title("foo").item();
+        Assertions.assertEquals("§rfoo§r", Objects.requireNonNull(itemStack.getItemMeta()).getDisplayName());
+
+        ItemStack itemStack2 = new ItemStackBuilder(Material.QUARTZ).title("foo ", "bar", " baz").item();
+        Assertions.assertEquals("§rfoo bar baz§r", Objects.requireNonNull(itemStack2.getItemMeta()).getDisplayName());
+
+        ItemStack itemStack3 = new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo").item();
+        Assertions.assertEquals("§r§afoo§r", Objects.requireNonNull(itemStack3.getItemMeta()).getDisplayName());
+
+        ItemStack itemStack4 = new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo ", "blue", " baz").item();
+        Assertions.assertEquals("§r§afoo blue baz§r", Objects.requireNonNull(itemStack4.getItemMeta()).getDisplayName());
+
+        ItemStack itemStack5 = new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo ").title("blue ").title("baz").item();
+        Assertions.assertEquals("§r§afoo §rblue §rbaz§r", Objects.requireNonNull(itemStack5.getItemMeta()).getDisplayName());
+
+        ItemStack itemStack6 = new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo ").title(ChatColor.BLUE, "blue ").title("baz").item();
+        Assertions.assertEquals("§r§afoo §r§9blue §rbaz§r", Objects.requireNonNull(itemStack6.getItemMeta()).getDisplayName());
+    }
+
+    @Test
+    public void canSetLore () {
+        ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ).lore("foo").item();
+        Assertions.assertEquals(Collections.singletonList("foo"), Objects.requireNonNull(itemStack.getItemMeta()).getLore());
+
+        ItemStack itemStack2 = new ItemStackBuilder(Material.QUARTZ).lore("foo", "bar", "baz").item();
+        Assertions.assertEquals(Arrays.asList("foo", "bar", "baz"), Objects.requireNonNull(itemStack2.getItemMeta()).getLore());
+
+        ItemStack itemStack3 = new ItemStackBuilder(Material.QUARTZ).lore(Arrays.asList("foo", "bar", "baz")).item();
+        Assertions.assertEquals(Arrays.asList("foo", "bar", "baz"), Objects.requireNonNull(itemStack3.getItemMeta()).getLore());
+
+        ItemStack itemStack4 = new ItemStackBuilder(Material.QUARTZ).lore("foo", "bar").lore("baz").item();
+        Assertions.assertEquals(Arrays.asList("foo", "bar", "baz"), Objects.requireNonNull(itemStack4.getItemMeta()).getLore());
+
+        ItemStack itemStack5 = new ItemStackBuilder(Material.QUARTZ).loreLine("foo", " bar").loreLine("baz").item();
+        Assertions.assertEquals(Arrays.asList("foo bar", "baz"), Objects.requireNonNull(itemStack5.getItemMeta()).getLore());
+
+        ItemStack itemStack6 = new ItemStackBuilder(Material.QUARTZ).loreLine("foo", " bar").lore("baz", "boo").item();
+        Assertions.assertEquals(Arrays.asList("foo bar", "baz", "boo"), Objects.requireNonNull(itemStack6.getItemMeta()).getLore());
+
+        ItemStack itemStack7 = new ItemStackBuilder(Material.QUARTZ).loreLine(ChatColor.GREEN, "foo", " bar").loreLine("baz").item();
+        Assertions.assertEquals(Arrays.asList("§afoo bar", "baz"), Objects.requireNonNull(itemStack7.getItemMeta()).getLore());
+
+        ItemStack itemStack8 = new ItemStackBuilder(Material.QUARTZ)
+                .loreLine("foo")
+                .longLore(ChatColor.GREEN, "Lorem ipsum dolor sit amet, consectetur adipiscing elit.").loreLine("bar").item();
+        Assertions.assertEquals(Arrays.asList("foo",
+                "§aLorem ipsum dolor sit amet,",
+                "§aconsectetur adipiscing elit.",
+                "bar"), Objects.requireNonNull(itemStack8.getItemMeta()).getLore());
+
+        ItemStack itemStack9 = new ItemStackBuilder(Material.QUARTZ)
+                .loreLine("foo")
+                .longLore(ChatColor.GREEN, "Lorem ipsum dolor sit amet", 10).loreLine("bar").item();
+        Assertions.assertEquals(Arrays.asList("foo",
+                "§aLorem",
+                "§aipsum",
+                "§adolor sit",
+                "§aamet",
+                "bar"), Objects.requireNonNull(itemStack9.getItemMeta()).getLore());
+
+        ItemStack itemStack10 = new ItemStackBuilder(Material.QUARTZ)
+                .loreLine("foo")
+                .loreSeparator()
+                .loreLine("bar").item();
+        Assertions.assertEquals(Arrays.asList("foo", "", "bar"), Objects.requireNonNull(itemStack10.getItemMeta()).getLore());
+
+        ItemStack itemStack11 = new ItemStackBuilder(Material.QUARTZ)
+                .loreLine("foo")
+                .resetLore()
+                .loreLine("bar").item();
+        Assertions.assertEquals(Collections.singletonList("bar"), Objects.requireNonNull(itemStack11.getItemMeta()).getLore());
+    }
+}

--- a/src/test/java/fr/zcraft/quartzlib/tools/reflection/ReflectionTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/tools/reflection/ReflectionTest.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import junit.framework.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReflectionTest 
 {

--- a/src/test/java/fr/zcraft/ztoaster/Toast.java
+++ b/src/test/java/fr/zcraft/ztoaster/Toast.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.zcraft.ztoaster;
+
+public class Toast 
+{
+    public enum CookingStatus {COOKED, NOT_COOKED}
+    
+    private CookingStatus status = CookingStatus.NOT_COOKED;
+    private final int toastId;
+    
+    public Toast()
+    {
+        toastId = Toaster.newToastId();
+    }
+    
+    public CookingStatus getStatus()
+    {
+        return status;
+    }
+
+    public void setStatus(CookingStatus status)
+    {
+        this.status = status;
+    }
+
+    public int getToastId()
+    {
+        return toastId;
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/ToastExplorer.java
+++ b/src/test/java/fr/zcraft/ztoaster/ToastExplorer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.zcraft.ztoaster;
+
+import fr.zcraft.quartzlib.components.gui.ExplorerGui;
+import fr.zcraft.quartzlib.components.gui.GuiUtils;
+import fr.zcraft.quartzlib.components.i18n.I;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class ToastExplorer extends ExplorerGui<Toast>
+{
+    @Override
+    protected void onUpdate()
+    {
+        setTitle(I.t(getPlayerLocale(), "{black}Toaster contents"));
+        
+        setData(Toaster.getToasts());
+        
+        //DO NOT TOUCH THE TOASTS !
+        setMode(ExplorerGui.Mode.READONLY);
+    }
+    
+    @Override
+    protected ItemStack getViewItem(Toast toast)
+    {
+        if(toast.getStatus().equals(Toast.CookingStatus.COOKED))
+            // Title of the cooked toast item in GUI
+            return GuiUtils.makeItem(Material.COOKED_PORKCHOP, I.t(getPlayerLocale(), "{white}Cooked toast #{0}", toast.getToastId()));
+        else
+            // Title of the raw toast item in GUI
+            return GuiUtils.makeItem(Material.PORKCHOP, I.t(getPlayerLocale(), "{white}Raw toast #{0}", toast.getToastId()));
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/Toaster.java
+++ b/src/test/java/fr/zcraft/ztoaster/Toaster.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.zcraft.ztoaster;
+
+import fr.zcraft.quartzlib.components.commands.Commands;
+import fr.zcraft.quartzlib.components.gui.Gui;
+import fr.zcraft.quartzlib.components.i18n.I18n;
+import fr.zcraft.quartzlib.components.scoreboard.Sidebar;
+import fr.zcraft.quartzlib.components.scoreboard.SidebarScoreboard;
+import fr.zcraft.quartzlib.core.QuartzPlugin;
+import fr.zcraft.quartzlib.tools.PluginLogger;
+import fr.zcraft.ztoaster.commands.AddCommand;
+import fr.zcraft.ztoaster.commands.ListCommand;
+import fr.zcraft.ztoaster.commands.OpenCommand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.plugin.java.JavaPluginLoader;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Locale;
+
+
+public class Toaster extends QuartzPlugin implements Listener
+{
+    /**
+     * A counter for all the toasts created (until toaster restart).
+     */
+    static private int toastCounter = 0;
+    
+    /**
+     * A list of all the toasts.
+     */
+    static private ArrayList<Toast> toasts;
+
+    /**
+     * The screen of the toaster.
+     */
+    private Sidebar toasterSidebar;
+
+    protected Toaster(JavaPluginLoader loader, PluginDescriptionFile description, File dataFolder, File file)
+    {
+        super(loader, description, dataFolder, file);
+    }
+
+    @Override
+    public void onEnable()
+    {
+        PluginLogger.info("Setting up toaster.");
+        
+        toasts = new ArrayList<>();
+        toastCounter = 0;
+        
+        loadComponents(Gui.class, Commands.class, ToasterWorker.class, SidebarScoreboard.class, I18n.class);
+        
+        Commands.register("toaster", AddCommand.class, OpenCommand.class, ListCommand.class);
+
+        I18n.useDefaultPrimaryLocale();
+        I18n.setFallbackLocale(Locale.US);
+
+        getServer().getPluginManager().registerEvents(this, this);
+
+
+        toasterSidebar = new ToasterSidebar();
+
+        for (Player player : getServer().getOnlinePlayers())
+            toasterSidebar.addRecipient(player);
+
+        toasterSidebar.runAutoRefresh(true);
+    }
+    
+    @Override
+    public void onDisable()
+    {
+        PluginLogger.info("Unplugging toaster.");
+    }
+
+
+    /**
+     * @return The id for a new toast.
+     */
+    static public int newToastId()
+    {
+        return toastCounter++;
+    }
+    
+    /**
+     * @return an array of all the toasts ever created (until toaster restart).
+     */
+    static public Toast[] getToasts()
+    {
+        return toasts.toArray(new Toast[toasts.size()]);
+    }
+    
+    /**
+     * Adds a new toast to the world.
+     * @return the newly created toast.
+     */
+    static public Toast newToast()
+    {
+        Toast toast = new Toast();
+        toasts.add(toast);
+        return toast;
+    }
+
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerJoin(PlayerJoinEvent ev)
+    {
+        toasterSidebar.addRecipient(ev.getPlayer());
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/ToasterSidebar.java
+++ b/src/test/java/fr/zcraft/ztoaster/ToasterSidebar.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+package fr.zcraft.ztoaster;
+
+import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.quartzlib.components.i18n.I18n;
+import fr.zcraft.quartzlib.components.scoreboard.Sidebar;
+import fr.zcraft.quartzlib.components.scoreboard.SidebarMode;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+
+public class ToasterSidebar extends Sidebar
+{
+    private int toastsCount = 0;
+    private int insideTheToaster = 0;
+
+
+    public ToasterSidebar()
+    {
+        setAsync(true);
+        setContentMode(SidebarMode.PER_PLAYER);
+        setAutoRefreshDelay(10);
+    }
+
+
+    @Override
+    public void preRender()
+    {
+        Toast[] toasts = Toaster.getToasts();
+
+        toastsCount = toasts.length;
+
+        insideTheToaster = 0;
+        for (Toast toast : toasts)
+        {
+            if (toast.getStatus() == Toast.CookingStatus.NOT_COOKED)
+                insideTheToaster++;
+        }
+    }
+    
+    @Override
+    public List<String> getContent(Player player)
+    {
+        Locale playerLocale = I18n.getPlayerLocale(player);
+        return Arrays.asList(
+                I.t(playerLocale, "{darkgreen}{bold}Cook"),
+                player.getDisplayName(),
+                "",
+                I.t(playerLocale, "{yellow}{bold}Inside the toaster"),
+                insideTheToaster + "",
+                "",
+                I.t(playerLocale, "{gold}{bold}Cooked"),
+                (toastsCount - insideTheToaster) + ""
+        );
+    }
+
+    @Override
+    public String getTitle(Player player)
+    {
+        if(insideTheToaster > 0)
+            return I.t(I18n.getPlayerLocale(player), "{red}{bold}\u2668 Toaster \u2668");
+
+        else
+            return I.t(I18n.getPlayerLocale(player), "{blue}Toaster");
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/ToasterWorker.java
+++ b/src/test/java/fr/zcraft/ztoaster/ToasterWorker.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+
+package fr.zcraft.ztoaster;
+
+import fr.zcraft.quartzlib.components.gui.Gui;
+import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.quartzlib.components.worker.Worker;
+import fr.zcraft.quartzlib.components.worker.WorkerCallback;
+import fr.zcraft.quartzlib.components.worker.WorkerRunnable;
+import fr.zcraft.quartzlib.tools.PluginLogger;
+import org.bukkit.entity.Player;
+
+public class ToasterWorker extends Worker
+{
+    /**
+     * Optimal cooking time for making carefully baked toasts.
+     */
+    static public int TOAST_COOKING_TIME = 4269;
+    
+    static public Toast addToast(final Player cook)
+    {
+        return ToasterWorker.addToast(new WorkerCallback<Integer>()
+        {
+            @Override
+            public void finished(Integer toastId)
+            {
+                I.sendT(cook, "DING! Toast {0} is ready !", toastId);
+                Gui.update(ToastExplorer.class);
+            }
+
+            @Override
+            public void errored(Throwable exception)
+            {
+                PluginLogger.error("Error while toasting", exception);
+                I.sendT(cook, "{ce}Oh no! A toasted exception !");
+                I.sendT(cook, "{ce}See toaster logs for details.");
+            }
+        });
+    }
+    
+    /**
+     * Creates a new toast, and adds it to the toaster queue.
+     * @param callback The callback to call when a toast is cooked.
+     * @return the newly created toast.
+     */
+    static public Toast addToast(WorkerCallback<Integer> callback)
+    {
+        final Toast newToast = Toaster.newToast();
+        final int toastId = newToast.getToastId();
+        
+        submitQuery(new WorkerRunnable()
+        {
+            @Override
+            public Object run() throws Throwable
+            {
+                PluginLogger.info("Cooking toast #{0} ...", toastId);
+                
+                Thread.sleep(TOAST_COOKING_TIME);
+                
+                PluginLogger.info("Toast #{0} cooked !", toastId);
+                
+                newToast.setStatus(Toast.CookingStatus.COOKED);
+                
+                return toastId;
+            }
+        }, callback);
+        
+        return newToast;
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/commands/AddCommand.java
+++ b/src/test/java/fr/zcraft/ztoaster/commands/AddCommand.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.zcraft.ztoaster.commands;
+
+import fr.zcraft.quartzlib.components.commands.Command;
+import fr.zcraft.quartzlib.components.commands.CommandException;
+import fr.zcraft.quartzlib.components.commands.CommandInfo;
+import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.ztoaster.Toast;
+import fr.zcraft.ztoaster.ToasterWorker;
+import org.bukkit.entity.Player;
+
+
+@CommandInfo(name = "add", usageParameters = "[toast count]")
+public class AddCommand extends Command
+{
+    @Override
+    protected void run() throws CommandException
+    {
+        Player cook = playerSender();
+        
+        if(args.length == 0)
+        {
+            Toast toast = ToasterWorker.addToast(cook);
+            cook.sendMessage(I.t("Toast {0} added.", toast.getToastId()));
+        }
+        else
+        {
+            int toastCount = getIntegerParameter(0);
+            for(int i = toastCount; i --> 0;)
+            {
+                ToasterWorker.addToast(cook);
+            }
+            
+            cook.sendMessage(I.tn("One toast added.", "{0} toasts added.", toastCount, toastCount));
+        }
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/commands/ListCommand.java
+++ b/src/test/java/fr/zcraft/ztoaster/commands/ListCommand.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.zcraft.ztoaster.commands;
+
+import fr.zcraft.quartzlib.components.commands.Command;
+import fr.zcraft.quartzlib.components.commands.CommandException;
+import fr.zcraft.quartzlib.components.commands.CommandInfo;
+import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.ztoaster.Toast;
+import fr.zcraft.ztoaster.Toaster;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@CommandInfo(name = "list", usageParameters = "[cooked|not_cooked]")
+public class ListCommand extends Command
+{
+    @Override
+    protected void run() throws CommandException
+    {
+        if(args.length == 0)
+        {
+            showToasts(Arrays.asList(Toaster.getToasts()));
+        }
+        else
+        {
+            ArrayList<Toast> toasts = new ArrayList<Toast>();
+            Toast.CookingStatus status = getEnumParameter(0, Toast.CookingStatus.class);
+            
+            for(Toast toast : Toaster.getToasts())
+            {
+                if(toast.getStatus().equals(status))
+                    toasts.add(toast);
+            }
+            
+            showToasts(toasts);
+        }
+    }
+    
+    private void showToasts(Collection<Toast> toasts)
+    {
+        if(toasts.isEmpty())
+        {
+            // Output of the command /toaster list, without toasts.
+            info(I.t("There are no toasts here ..."));
+        }
+        
+        for(Toast toast : toasts)
+        {
+            sender.sendMessage(I.t("  Toast #{0}", toast.getToastId()));
+        }
+    }
+}

--- a/src/test/java/fr/zcraft/ztoaster/commands/OpenCommand.java
+++ b/src/test/java/fr/zcraft/ztoaster/commands/OpenCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+
+package fr.zcraft.ztoaster.commands;
+
+import fr.zcraft.quartzlib.components.commands.Command;
+import fr.zcraft.quartzlib.components.commands.CommandException;
+import fr.zcraft.quartzlib.components.commands.CommandInfo;
+import fr.zcraft.quartzlib.components.gui.Gui;
+import fr.zcraft.ztoaster.ToastExplorer;
+
+@CommandInfo(name = "open")
+public class OpenCommand extends Command
+{
+    @Override
+    protected void run() throws CommandException
+    {
+        Gui.open(playerSender(), new ToastExplorer());
+    }
+}

--- a/src/test/resources/i18n/en_US.po
+++ b/src/test/resources/i18n/en_US.po
@@ -18,75 +18,70 @@ msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Plural-Forms: nplurals=2; plural=n>1;\n"
 
 #: fr/zcraft/ztoaster/ToasterSidebar.java:75
-msgctxt "sidebar"
 msgid   "{darkgreen}{bold}Cook"
-msgstr  "{darkgreen}{bold}Cuistot"
+msgstr  "{darkgreen}{bold}Cook"
 
 #: fr/zcraft/ztoaster/ToasterSidebar.java:78
-msgctxt "sidebar"
 msgid   "{yellow}{bold}Inside the toaster"
-msgstr  "{yellow}{bold}Dans le grille-pain"
+msgstr  "{yellow}{bold}Inside da toasterr"
 
 #: fr/zcraft/ztoaster/ToasterSidebar.java:81
-msgctxt "sidebar"
 msgid   "{gold}{bold}Cooked"
-msgstr  "{gold}{bold}Cuit"
+msgstr  "{gold}{bold}Cooked"
 
 #: fr/zcraft/ztoaster/ToasterSidebar.java:90
-msgctxt "sidebar"
 msgid   "{red}{bold}♨ Toaster ♨"
-msgstr  "{red}{bold}♨ Grille-pain ♨"
+msgstr  "{red}{bold}♨ Toaster ♨"
 
 #: fr/zcraft/ztoaster/ToasterSidebar.java:93
-msgctxt "sidebar"
 msgid   "{blue}Toaster"
-msgstr  "{blue}Grille-pain"
+msgstr  "{blue}Toaster"
 
 #: fr/zcraft/ztoaster/ToastExplorer.java:44
 msgid   "{black}Toaster contents"
-msgstr  "{black}Contenu du grille-pain"
+msgstr   "{black}Toaster contents"
 
 #. Title of the cooked toast item in GUI
 #: fr/zcraft/ztoaster/ToastExplorer.java:57
 msgid   "{white}Cooked toast #{0}"
-msgstr  "{white}Pain grillé no. {0}"
+msgstr   "{white}Cooked toast #{0}"
 
 #. Title of the raw toast item in GUI
 #: fr/zcraft/ztoaster/ToastExplorer.java:60
 msgid   "{white}Raw toast #{0}"
-msgstr  "{white}Pain pas grillé no. {0}"
+msgstr   "{white}Raw toast #{0}"
 
 #: fr/zcraft/ztoaster/commands/AddCommand.java:56
 #, possible-java-format
 msgid   "DING! Toast {0} is ready !"
-msgstr  "DING ! Le pain grillé {0} est prêt !"
+msgstr  "DING! Toast {0} is ready !"
 
 #: fr/zcraft/ztoaster/commands/AddCommand.java:64
 msgid   "{ce}Oh no! A toasted exception !"
-msgstr  "{ce}Oh non ! Une exception grillée !"
+msgstr  "{ce}Oh no! A toasted exception !"
 
 #: fr/zcraft/ztoaster/commands/AddCommand.java:65
 msgid   "{ce}See toaster logs for details."
-msgstr  "{ce}Voir les logs du grille-pain pour plus de détails."
+msgstr  "{ce}See toaster logs for details."
 
 #: fr/zcraft/ztoaster/commands/AddCommand.java:69
 #, possible-java-format
 msgid   "Toast {0} added."
-msgstr  "Pain {0} ajouté."
+msgstr  "Toast {0} added."
 
 #: fr/zcraft/ztoaster/commands/AddCommand.java:63
 #, java-format
 msgid   "One toast added."
 msgid_plural "{0} toasts added."
-msgstr[0]  "Un pain ajouté."
-msgstr[1]  "{0} pains ajoutés."
+msgstr[0]  "One toast added."
+msgstr[1]  "{0} toasts added."
 
 #. Output of the command /toaster list, without toasts.
 #: fr/zcraft/ztoaster/commands/ListCommand.java:74
 msgid   "There are no toasts here ..."
-msgstr  "Il n'y a pas de pain grillé ici..."
+msgstr  "There are no toasts here ..."
 
 #: fr/zcraft/ztoaster/commands/ListCommand.java:79
 #, java-format
 msgid   "  Toast #{0}"
-msgstr  "  Pain grillé no. {0}"
+msgstr  "  Toast #{0}"

--- a/src/test/resources/i18n/fr_FR.po
+++ b/src/test/resources/i18n/fr_FR.po
@@ -1,7 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Testing data for the PO parser and translator
+# Copyright (C) 2015-2020 QuartzLib contributors
+# This file is distributed under the CeCILL-B license.
 #
 #, fuzzy
 msgid   ""
@@ -90,3 +89,38 @@ msgstr  "Il n'y a pas de pain grillé ici..."
 #, java-format
 msgid   "  Toast #{0}"
 msgstr  "  Pain grillé no. {0}"
+
+#: fr/zcraft/ztoaster/Nowhere.java:4269
+msgid   "It's just a \"toaster\""
+msgstr  "Ce n'est qu'un \"toaster\""
+
+#: fr/zcraft/ztoaster/Nowhere.java:1984
+msgid   "Multi-lines"
+"message"
+msgstr  "Message"
+"multi-ligne"
+
+#: fr/zcraft/ztoaster/Nowhere.java:1984
+msgid   "Multi-lines "
+"message with trailing space"
+msgstr  "Message"
+" multi-ligne avec une espace séparatrice explicite"
+
+#: fr/zcraft/ztoaster/Nowhere.java:1337
+msgid   "Multi-lines "
+" message with multiple trailing spaces"
+msgstr  "Message "
+" multi-ligne avec plusieurs espaces séparatrices explicites"
+
+#: src/main/java/eu/carrade/amaury/UHCReloaded/borders/BorderManager.java:426
+msgid ""
+"{gray}It will shrink by one block every {0} second(s) until {1} blocks in "
+"diameter."
+msgstr ""
+"{gray}Elle réduira d'un bloc toutes les {0} seconde(s) jusqu'à atteindre "
+"{1} blocs de diamètre."
+
+#msgid "{gray}When clicked, a sign will open; write the name of the team inside."
+#msgstr ""
+#"{gray}Cliquez ici pour ouvrir un panneau, et écrivez le nom de l'équipe "
+#"dedans."

--- a/src/test/resources/plugin.yml
+++ b/src/test/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: zToaster
+main: fr.zcraft.ztoaster.Toaster
+version: 0.99
+
+commands:
+   toaster:
+      description: Toaster Interface


### PR DESCRIPTION
This PR refreshes and improves the test harness for QuartzLib, doing the following:

- JUnit has been updated to JUnit5 (mainly enabling more modern Java 8-based APIs and parallel test running)
- The [MockBukkit](https://github.com/seeseemelk/MockBukkit) library has been added as a test dependency, to allow us to greatly expand our test coverage in the future
- The old [zToaster](https://github.com/zDevelopers/zToaster) example plugin has been moved in-tree, allowing us to further expand both current and potential test coverage, as well as strongly reducing potential API breakages
- As the i18n translation (`.po`) files were loosely based on zToaster's, they have been merged together, and the i18n tests updated accordingly.
- A decent amount of tests for the [`ItemStackBuilder`](https://zdevelopers.github.io/QuartzLib/?fr/zcraft/zlib/core/QuartzPlugin.html) API were added, although there is no full coverage yet. No changes to ItemStackBuilder have been made, other than minor documentation fixes.