### PR TITLE
Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _Published one day_
 
 #### `ItemStackBuilder`
 
-- **Breaking Change** — We renamed the `ItemStackBuilder.hideAttributes()` to `ItemStackBuilder.hideAllAttributes()` for clarity.
+- :warning: We renamed the `ItemStackBuilder.hideAttributes()` to `ItemStackBuilder.hideAllAttributes()` for clarity.
 
 
 
@@ -54,7 +54,7 @@ _Published one day_
 
 #### `ItemStackBuilder`
 
-- **Breaking Change** — We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new ``ItemStackBuilder.withMeta()` method.
+- **Breaking Change** — We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new `ItemStackBuilder.withMeta()` method.
 
 #### `GuiUtils`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,10 +72,6 @@ _Published one day_
   - `hideItemAttributes(ItemMeta)`
   - `hideItemAttributes(ItemStack)`
 
-
-
-
-
 ## QuartzLib 0.0.1
 
 _Published 12 November, 2020_
@@ -88,12 +84,12 @@ _Published 12 November, 2020_
 
 #### Moved Maven repository
 
-:warning: You must use our new (and now, stable) repository, at `https://maven.pkg.github.com/zDevelopers/QuartzLib`. To do so, put his in your `pom.xml`, instead of the old repository:
+:warning: You must use our new (and now, stable) repository, at `https://maven.zcraft.fr/QuartzLib`. To do so, put his in your `pom.xml`, instead of the old repository:
 
 ```xml
     <repository>
         <id>zdevelopers-quartzlib</id>
-        <url>https://maven.pkg.github.com/zDevelopers/QuartzLib</url>
+        <url>https://maven.zcraft.fr/QuartzLib</url>
     </repository>
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,15 +54,15 @@ _Published one day_
 
 ### Removed
 
-#### `ItemStackBuilder`
-
-- :warning: We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new `ItemStackBuilder.withMeta()` method.
-
 #### `GuiUtils`
 
 - :warning: We removed the following methods from `GuiUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use `ItemStackBuilder.hideAllAttributes()` instead.
   - `GuiUtils.hideItemAttributes(ItemMeta)`
   - `GuiUtils.hideItemAttributes(ItemStack)`
+
+#### `ItemStackBuilder`
+
+- :warning: We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new `ItemStackBuilder.withMeta()` method.
 
 #### `ItemUtils`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,144 @@
+# QuartzLib Changelog
+
+This document explains how QuartzLib evolved from version to version, starting at 0.0.1 (the version after zLib 0.99), and how to migrate your code if there are breaking changes.
+
+We follow semantic versioning: you can tell if a version contains breaking changes by looking at the evolution of the version number.
+
+
+
+## QuartzLib 0.1
+
+_Published one day_
+
+### Added
+
+#### `ItemStackBuilder`
+
+- We added a [`withMeta()`](https://zdevelopers.github.io/QuartzLib/fr/zcraft/quartzlib/tools/items/ItemStackBuilder.html#withMeta-java.util.function.Consumer-)  method to alter the `ItemMeta` of the built item. Use it like this.
+
+  ```java
+   final ItemStack skull = new ItemStackBuilder(Material.PLAYER_HEAD)
+       .withMeta((SkullMeta s) -> s.setOwner("foo"))
+       .item();
+  ```
+
+  This method can be called multiple times, and if so, all callbacks will be executed.
+  If the meta is not of the right type, the callback will be ignored without error. You can chain multiple `withMeta()` calls; only the ones matching the item type will be called.
+
+- We added a [`withFlags(ItemFlag...)`](https://zdevelopers.github.io/QuartzLib/fr/zcraft/quartzlib/tools/items/ItemStackBuilder.html#withFlags-org.bukkit.inventory.ItemFlag...-)  method to add the given item flags to the built item. As example, to hide enchantments and unbreakable state from an item, use it like this.
+
+  ```java
+  final ItemStack item = new ItemStackBuilder(Material.QUARTZ)
+      .withFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_UNBREAKABLE)
+      .item();
+  ```
+
+  To hide _all_ attributes from the item, use `hideAllAttributes()`.
+
+#### Tests
+
+- We now use MockBukkit to greatly increase our tests coverage.
+- A sample QuartzLib plugin is now available in the repository. We also use it for tests. Check it out at ` src/test/java/fr/zcraft/ztoaster`.
+
+
+
+### Changed
+
+#### `ItemStackBuilder`
+
+- **Breaking Change** — We renamed the `ItemStackBuilder.hideAttributes()` to `ItemStackBuilder.hideAllAttributes()` for clarity.
+
+
+
+### Removed
+
+#### `ItemStackBuilder`
+
+- **Breaking Change** — We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new ``ItemStackBuilder.withMeta()` method.
+
+#### `GuiUtils`
+
+- **Breaking Change** — We removed the following methods from `GuiUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use `ItemStackBuilder.hideAllAttributes()` instead.
+  - `GuiUtils.hideItemAttributes(ItemMeta)`
+  - `GuiUtils.hideItemAttributes(ItemStack)`
+
+#### `ItemUtils`
+
+- **Breaking Change** — We removed the following methods from `ItemUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use their equivalent in `ItemStackBuilder` instead.
+  - `hasItemFlag(ItemMeta, String)`
+  - `removeItemFlags(ItemMeta, String...)`
+  - `hideItemAttributes(ItemMeta)`
+  - `hideItemAttributes(ItemStack)`
+
+
+
+
+
+## QuartzLib 0.0.1
+
+_Published 12 November, 2020_
+
+### Changed
+
+#### Higher base requirements
+
+**Breaking Change** — QuartzLib now requires Java 8+ (instead of 7+) and Bukkit 1.15+ (instead of 1.8.3+).
+
+#### Moved Maven repository
+
+**Breaking Change** — You must use our new (and now, stable) repository, at `https://maven.pkg.github.com/zDevelopers/QuartzLib`. To do so, put his in your `pom.xml`, instead of the old repository:
+
+```xml
+    <repository>
+        <id>zdevelopers-quartzlib</id>
+        <url>https://maven.pkg.github.com/zDevelopers/QuartzLib</url>
+    </repository>
+```
+
+Also, the artifact ID changed to reflect the new name. You should update the dependency like so:
+
+```xml
+    <dependency>
+        <groupId>fr.zcraft</groupId>
+        <artifactId>quartzlib</artifactId>
+        <version>0.0.1</version>
+    </dependency>
+```
+
+Of course, feel free to update the version if new versions have been released when you read this.
+
+Finally, as the package changed too, you should update your shading settings. Update the `configuration` tag like this:
+
+```xml
+                     <artifactSet>
+                         <includes>
+                             <include>fr.zcraft:quartzlib</include>
+                         </includes>
+                     </artifactSet>
+                     <relocations>
+                         <relocation>
+                             <pattern>fr.zcraft.quartzlib</pattern>
+                             <shadedPattern>YOUR.OWN.PACKAGE.quartzlib</shadedPattern>
+                         </relocation>
+                     </relocations>
+```
+
+…keeping other shading as is, if any.
+
+#### Renamed packages and classes
+
+**Breaking Change** — zLib is now QuartzLib, so a lot of things were renamed.
+
+- The base package `fr.zcraft.zlib` is now `fr.zcraft.quartzlib`.
+- The `ZLib` class is now `QuartzLib`.
+- The `ZLibComponent` class is now `QuartzComponent`.
+- The `ZPlugin` class is now `QuartzPlugin`.
+
+Just rename these references—the interfaces have remained the same.
+
+### Removed
+
+#### `RawText`
+
+- **Breaking Change** — Removed `Achievement`-related methods from the raw text component, as these are no longer supported in Minecraft 1.15+.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This document explains how QuartzLib evolved from version to version, starting a
 
 We follow semantic versioning: you can tell if a version contains breaking changes by looking at the evolution of the version number.
 
+Changes marked with :warning: are **breaking changes**.
+
 
 
 ## QuartzLib 0.1
@@ -54,17 +56,17 @@ _Published one day_
 
 #### `ItemStackBuilder`
 
-- **Breaking Change** — We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new `ItemStackBuilder.withMeta()` method.
+- :warning: We removed the `ItemStackBuilder.dye(DyeColor)` and `ItemStackBuilder.head(String)` methods. The first one can be replaced by the right material, as in 1.13+ each dyed version has its own material. For the second one, use the new `ItemStackBuilder.withMeta()` method.
 
 #### `GuiUtils`
 
-- **Breaking Change** — We removed the following methods from `GuiUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use `ItemStackBuilder.hideAllAttributes()` instead.
+- :warning: We removed the following methods from `GuiUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use `ItemStackBuilder.hideAllAttributes()` instead.
   - `GuiUtils.hideItemAttributes(ItemMeta)`
   - `GuiUtils.hideItemAttributes(ItemStack)`
 
 #### `ItemUtils`
 
-- **Breaking Change** — We removed the following methods from `ItemUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use their equivalent in `ItemStackBuilder` instead.
+- :warning: We removed the following methods from `ItemUtils`, as they were duplicates of `ItemStackBuilder` ones, or using deprecated APIs. Use their equivalent in `ItemStackBuilder` instead.
   - `hasItemFlag(ItemMeta, String)`
   - `removeItemFlags(ItemMeta, String...)`
   - `hideItemAttributes(ItemMeta)`
@@ -82,11 +84,11 @@ _Published 12 November, 2020_
 
 #### Higher base requirements
 
-**Breaking Change** — QuartzLib now requires Java 8+ (instead of 7+) and Bukkit 1.15+ (instead of 1.8.3+).
+:warning: QuartzLib now requires Java 8+ (instead of 7+) and Bukkit 1.15+ (instead of 1.8.3+).
 
 #### Moved Maven repository
 
-**Breaking Change** — You must use our new (and now, stable) repository, at `https://maven.pkg.github.com/zDevelopers/QuartzLib`. To do so, put his in your `pom.xml`, instead of the old repository:
+:warning: You must use our new (and now, stable) repository, at `https://maven.pkg.github.com/zDevelopers/QuartzLib`. To do so, put his in your `pom.xml`, instead of the old repository:
 
 ```xml
     <repository>
@@ -127,7 +129,7 @@ Finally, as the package changed too, you should update your shading settings. Up
 
 #### Renamed packages and classes
 
-**Breaking Change** — zLib is now QuartzLib, so a lot of things were renamed.
+:warning: zLib is now QuartzLib, so a lot of things were renamed.
 
 - The base package `fr.zcraft.zlib` is now `fr.zcraft.quartzlib`.
 - The `ZLib` class is now `QuartzLib`.
@@ -140,5 +142,5 @@ Just rename these references—the interfaces have remained the same.
 
 #### `RawText`
 
-- **Breaking Change** — Removed `Achievement`-related methods from the raw text component, as these are no longer supported in Minecraft 1.15+.
+- :warning: Removed `Achievement`-related methods from the raw text component, as these are no longer supported in Minecraft 1.15+.
 


### PR DESCRIPTION
This PR starts a changelog/migration guide for QuartzLib.

It includes the migration from zLib 0.99 to QuartzLib 0.0.1, and the first PRs: #49 and #50.

The objective is to update the changelog in each PR.