### PR TITLE
Repository update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Either create a plugin as usual and add the QuartzLib as explained below, or use
 #### I want to add QuartzLib to an existing project
 
 1. Add our Maven repository to your `pom.xml` file.
-   
+  
     ```xml
         <repository>
             <id>QuartzLib</id>
-            <url>https://maven.pkg.github.com/zDevelopers/QuartzLib</url>
+            <url>https://maven.zcraft.fr/QuartzLib</url>
         </repository>
     ```
 
 2. Add QuartzLib as a dependency.
-   
+  
     ```xml
         <dependency>
             <groupId>fr.zcraft</groupId>
@@ -37,7 +37,7 @@ Either create a plugin as usual and add the QuartzLib as explained below, or use
     ```
     
 3. Add the shading plugin to the build. Replace **`YOUR.OWN.PACKAGE`** with your own package.
-    
+  
    ```xml
         <build>
             ...
@@ -76,7 +76,7 @@ Either create a plugin as usual and add the QuartzLib as explained below, or use
    ```
    
 4. Build your project as usual, as example with the following command from your working directory, or using an integrated tool from your IDE.
-   
+  
    ```bash
    mvn clean install
    ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Either create a plugin as usual and add the QuartzLib as explained below, or use
         <dependency>
             <groupId>fr.zcraft</groupId>
             <artifactId>quartzlib</artifactId>
-            <version>0.99-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     ```
     

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
 		<repository>
 			<id>github</id>
 			<name>GitHub Packages</name>
+      <!-- For public access, use https://maven.zcraft.fr/QuartzLib instead (it's the same repo under the hood). -->
 			<url>https://maven.pkg.github.com/zDevelopers/QuartzLib</url>
 		</repository>
 	</distributionManagement>


### PR DESCRIPTION
As GitHub wants authenticated requests to GitHub Package, we created a proxy to add the correct authentication header. The new Maven repo to use is `https://maven.zcraft.fr/<repo>` (e.g. `https://maven.zcraft.fr/QuartzLib`), but the back-end is still GitHub Packages.

This PR updates the README.

QA: double-check the URL.