### PR TITLE
Update JUnit so we can run MockBukkit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>com.github.seeseemelk</groupId>
 			<artifactId>MockBukkit-v1.16</artifactId>
-			<version>0.5.0</version>
+			<version>0.16.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<junit.version>4.13.1</junit.version>
 		<revision>0.0.1-SNAPSHOT</revision>
 	</properties>
 	
@@ -59,6 +60,11 @@
                     <target>8</target>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M5</version>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -96,6 +102,18 @@
 		</repository>
 	</repositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>5.7.0</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.bukkit</groupId>
@@ -121,19 +139,32 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.0</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>com.github.seeseemelk</groupId>
 			<artifactId>MockBukkit-v1.16</artifactId>
-			<version>0.16.0</version>
+			<version>0.5.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedBukkitTest.java
@@ -2,8 +2,8 @@ package fr.zcraft.quartzlib;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * A simple base class for tests that just set up a Mock Bukkit server, without any plugin associated.
@@ -13,12 +13,12 @@ import org.junit.jupiter.api.BeforeEach;
 public abstract class MockedBukkitTest {
     protected ServerMock server;
 
-    @BeforeEach
+    @Before
     public void setup() {
         server = MockBukkit.mock();
     }
 
-    @AfterEach
+    @After
     public void tearDown() {
         MockBukkit.unmock();
     }

--- a/src/test/java/fr/zcraft/quartzlib/MockedToasterTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/MockedToasterTest.java
@@ -3,8 +3,8 @@ package fr.zcraft.quartzlib;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import fr.zcraft.ztoaster.Toaster;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * A base class for tests, that sets up a mock server and enables the Toaster plugin inside it.
@@ -13,13 +13,13 @@ public abstract class MockedToasterTest {
     protected ServerMock server;
     protected Toaster plugin;
 
-    @BeforeEach
+    @Before
     public void setUp() {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(Toaster.class);
     }
 
-    @AfterEach
+    @After
     public void tearDown() {
         MockBukkit.unmock();
     }

--- a/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/core/QuartzLibTest.java
@@ -3,7 +3,7 @@ package fr.zcraft.quartzlib.core;
 import static org.junit.Assert.assertSame;
 
 import fr.zcraft.quartzlib.MockedToasterTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 
 public class QuartzLibTest extends MockedToasterTest {

--- a/src/test/java/fr/zcraft/quartzlib/tools/items/ItemStackBuilderTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/tools/items/ItemStackBuilderTest.java
@@ -11,30 +11,34 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ItemStackBuilderTest extends MockedBukkitTest {
+    @Rule
+    public ExpectedException ilgStExceptionRule = ExpectedException.none();
+
     @Test
     public void throwsOnEmptyBuilder() {
-        IllegalStateException ex = Assertions.assertThrows(IllegalStateException.class,
-                () -> new ItemStackBuilder().item());
+        ilgStExceptionRule.expect(IllegalStateException.class);
+        ilgStExceptionRule.expectMessage("Cannot build item without a specified material");
 
-        Assertions.assertEquals("Cannot build item without a specified material", ex.getMessage());
+        new ItemStackBuilder().item();
     }
 
     @Test
     public void buildsWithDefaultAmount() {
-        Assertions.assertEquals(1, new ItemStackBuilder(Material.QUARTZ).item().getAmount());
+        Assert.assertEquals(1, new ItemStackBuilder(Material.QUARTZ).item().getAmount());
     }
 
     @Test
     public void canBuildBasicItemStack() {
         ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ, 42).item();
 
-        Assertions.assertEquals(Material.QUARTZ, itemStack.getType());
-        Assertions.assertEquals(42, itemStack.getAmount());
+        Assert.assertEquals(Material.QUARTZ, itemStack.getType());
+        Assert.assertEquals(42, itemStack.getAmount());
     }
 
     @Test
@@ -42,13 +46,13 @@ public class ItemStackBuilderTest extends MockedBukkitTest {
         ItemStack itemStack = new ItemStack(Material.QUARTZ, 42);
         new ItemStackBuilder(itemStack).amount(50).item();
 
-        Assertions.assertEquals(Material.QUARTZ, itemStack.getType());
-        Assertions.assertEquals(50, itemStack.getAmount());
+        Assert.assertEquals(Material.QUARTZ, itemStack.getType());
+        Assert.assertEquals(50, itemStack.getAmount());
 
         new ItemStackBuilder(itemStack).material(Material.DIORITE).item();
 
-        Assertions.assertEquals(Material.DIORITE, itemStack.getType());
-        Assertions.assertEquals(50, itemStack.getAmount());
+        Assert.assertEquals(Material.DIORITE, itemStack.getType());
+        Assert.assertEquals(50, itemStack.getAmount());
     }
 
     @Test
@@ -60,75 +64,75 @@ public class ItemStackBuilderTest extends MockedBukkitTest {
 
         new ItemStackBuilder(itemStack).item();
 
-        Assertions.assertEquals(Material.QUARTZ, itemStack.getType());
-        Assertions.assertEquals(42, itemStack.getAmount());
-        Assertions.assertEquals(Arrays.asList("foo", "bar"), itemStack.getItemMeta().getLore());
+        Assert.assertEquals(Material.QUARTZ, itemStack.getType());
+        Assert.assertEquals(42, itemStack.getAmount());
+        Assert.assertEquals(Arrays.asList("foo", "bar"), itemStack.getItemMeta().getLore());
     }
 
     @Test
     public void canSetDisplayName() {
         ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ).title("foo").item();
-        Assertions.assertEquals("§rfoo§r", Objects.requireNonNull(itemStack.getItemMeta()).getDisplayName());
+        Assert.assertEquals("§rfoo§r", Objects.requireNonNull(itemStack.getItemMeta()).getDisplayName());
 
         ItemStack itemStack2 = new ItemStackBuilder(Material.QUARTZ).title("foo ", "bar", " baz").item();
-        Assertions.assertEquals("§rfoo bar baz§r", Objects.requireNonNull(itemStack2.getItemMeta()).getDisplayName());
+        Assert.assertEquals("§rfoo bar baz§r", Objects.requireNonNull(itemStack2.getItemMeta()).getDisplayName());
 
         ItemStack itemStack3 = new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo").item();
-        Assertions.assertEquals("§r§afoo§r", Objects.requireNonNull(itemStack3.getItemMeta()).getDisplayName());
+        Assert.assertEquals("§r§afoo§r", Objects.requireNonNull(itemStack3.getItemMeta()).getDisplayName());
 
         ItemStack itemStack4 =
                 new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo ", "blue", " baz").item();
-        Assertions
+        Assert
                 .assertEquals("§r§afoo blue baz§r", Objects.requireNonNull(itemStack4.getItemMeta()).getDisplayName());
 
         ItemStack itemStack5 =
                 new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo ").title("blue ").title("baz").item();
-        Assertions.assertEquals("§r§afoo §rblue §rbaz§r",
+        Assert.assertEquals("§r§afoo §rblue §rbaz§r",
                 Objects.requireNonNull(itemStack5.getItemMeta()).getDisplayName());
 
         ItemStack itemStack6 =
                 new ItemStackBuilder(Material.QUARTZ).title(ChatColor.GREEN, "foo ").title(ChatColor.BLUE, "blue ")
                         .title("baz").item();
-        Assertions.assertEquals("§r§afoo §r§9blue §rbaz§r",
+        Assert.assertEquals("§r§afoo §r§9blue §rbaz§r",
                 Objects.requireNonNull(itemStack6.getItemMeta()).getDisplayName());
     }
 
     @Test
     public void canSetLore() {
         ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ).lore("foo").item();
-        Assertions.assertEquals(Collections.singletonList("foo"),
+        Assert.assertEquals(Collections.singletonList("foo"),
                 Objects.requireNonNull(itemStack.getItemMeta()).getLore());
 
         ItemStack itemStack2 = new ItemStackBuilder(Material.QUARTZ).lore("foo", "bar", "baz").item();
-        Assertions.assertEquals(Arrays.asList("foo", "bar", "baz"),
+        Assert.assertEquals(Arrays.asList("foo", "bar", "baz"),
                 Objects.requireNonNull(itemStack2.getItemMeta()).getLore());
 
         ItemStack itemStack3 = new ItemStackBuilder(Material.QUARTZ).lore(Arrays.asList("foo", "bar", "baz")).item();
-        Assertions.assertEquals(Arrays.asList("foo", "bar", "baz"),
+        Assert.assertEquals(Arrays.asList("foo", "bar", "baz"),
                 Objects.requireNonNull(itemStack3.getItemMeta()).getLore());
 
         ItemStack itemStack4 = new ItemStackBuilder(Material.QUARTZ).lore("foo", "bar").lore("baz").item();
-        Assertions.assertEquals(Arrays.asList("foo", "bar", "baz"),
+        Assert.assertEquals(Arrays.asList("foo", "bar", "baz"),
                 Objects.requireNonNull(itemStack4.getItemMeta()).getLore());
 
         ItemStack itemStack5 = new ItemStackBuilder(Material.QUARTZ).loreLine("foo", " bar").loreLine("baz").item();
-        Assertions.assertEquals(Arrays.asList("foo bar", "baz"),
+        Assert.assertEquals(Arrays.asList("foo bar", "baz"),
                 Objects.requireNonNull(itemStack5.getItemMeta()).getLore());
 
         ItemStack itemStack6 = new ItemStackBuilder(Material.QUARTZ).loreLine("foo", " bar").lore("baz", "boo").item();
-        Assertions.assertEquals(Arrays.asList("foo bar", "baz", "boo"),
+        Assert.assertEquals(Arrays.asList("foo bar", "baz", "boo"),
                 Objects.requireNonNull(itemStack6.getItemMeta()).getLore());
 
         ItemStack itemStack7 =
                 new ItemStackBuilder(Material.QUARTZ).loreLine(ChatColor.GREEN, "foo", " bar").loreLine("baz").item();
-        Assertions.assertEquals(Arrays.asList("§afoo bar", "baz"),
+        Assert.assertEquals(Arrays.asList("§afoo bar", "baz"),
                 Objects.requireNonNull(itemStack7.getItemMeta()).getLore());
 
         ItemStack itemStack8 = new ItemStackBuilder(Material.QUARTZ)
                 .loreLine("foo")
                 .longLore(ChatColor.GREEN, "Lorem ipsum dolor sit amet, consectetur adipiscing elit.").loreLine("bar")
                 .item();
-        Assertions.assertEquals(Arrays.asList("foo",
+        Assert.assertEquals(Arrays.asList("foo",
                 "§aLorem ipsum dolor sit amet,",
                 "§aconsectetur adipiscing elit.",
                 "bar"), Objects.requireNonNull(itemStack8.getItemMeta()).getLore());
@@ -136,7 +140,7 @@ public class ItemStackBuilderTest extends MockedBukkitTest {
         ItemStack itemStack9 = new ItemStackBuilder(Material.QUARTZ)
                 .loreLine("foo")
                 .longLore(ChatColor.GREEN, "Lorem ipsum dolor sit amet", 10).loreLine("bar").item();
-        Assertions.assertEquals(Arrays.asList("foo",
+        Assert.assertEquals(Arrays.asList("foo",
                 "§aLorem",
                 "§aipsum",
                 "§adolor sit",
@@ -147,14 +151,14 @@ public class ItemStackBuilderTest extends MockedBukkitTest {
                 .loreLine("foo")
                 .loreSeparator()
                 .loreLine("bar").item();
-        Assertions.assertEquals(Arrays.asList("foo", "", "bar"),
+        Assert.assertEquals(Arrays.asList("foo", "", "bar"),
                 Objects.requireNonNull(itemStack10.getItemMeta()).getLore());
 
         ItemStack itemStack11 = new ItemStackBuilder(Material.QUARTZ)
                 .loreLine("foo")
                 .resetLore()
                 .loreLine("bar").item();
-        Assertions.assertEquals(Collections.singletonList("bar"),
+        Assert.assertEquals(Collections.singletonList("bar"),
                 Objects.requireNonNull(itemStack11.getItemMeta()).getLore());
     }
 
@@ -164,50 +168,50 @@ public class ItemStackBuilderTest extends MockedBukkitTest {
                 .withMeta((SkullMeta s) -> s.setOwner("foo"))
                 .item();
 
-        Assertions.assertEquals(Material.PLAYER_HEAD, fooSkull.getType());
-        Assertions.assertEquals("foo", ((SkullMeta) Objects.requireNonNull(fooSkull.getItemMeta())).getOwner());
+        Assert.assertEquals(Material.PLAYER_HEAD, fooSkull.getType());
+        Assert.assertEquals("foo", ((SkullMeta) Objects.requireNonNull(fooSkull.getItemMeta())).getOwner());
 
         ItemStack quartz = new ItemStackBuilder(Material.QUARTZ)
                 .withMeta((SkullMeta s) -> s.setOwner("foo"))
                 .item();
 
-        Assertions.assertEquals(Material.QUARTZ, quartz.getType());
-        Assertions.assertFalse(Objects.requireNonNull(quartz.getItemMeta()) instanceof SkullMeta);
+        Assert.assertEquals(Material.QUARTZ, quartz.getType());
+        Assert.assertFalse(Objects.requireNonNull(quartz.getItemMeta()) instanceof SkullMeta);
     }
 
     @Test
     public void canAddFlags() {
         ItemStack itemStack = new ItemStackBuilder(Material.QUARTZ).withFlags(ItemFlag.HIDE_ATTRIBUTES).item();
         Set<ItemFlag> flags = Objects.requireNonNull(itemStack.getItemMeta()).getItemFlags();
-        Assertions.assertEquals(1, flags.size());
-        Assertions.assertTrue(flags.contains(ItemFlag.HIDE_ATTRIBUTES));
+        Assert.assertEquals(1, flags.size());
+        Assert.assertTrue(flags.contains(ItemFlag.HIDE_ATTRIBUTES));
 
         ItemStack itemStack2 =
                 new ItemStackBuilder(Material.QUARTZ).withFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)
                         .item();
         flags = Objects.requireNonNull(itemStack2.getItemMeta()).getItemFlags();
-        Assertions.assertEquals(2, flags.size());
-        Assertions.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)));
+        Assert.assertEquals(2, flags.size());
+        Assert.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)));
 
         ItemStack itemStack3 = new ItemStackBuilder(Material.QUARTZ)
                 .withFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS).item();
         flags = Objects.requireNonNull(itemStack3.getItemMeta()).getItemFlags();
-        Assertions.assertEquals(2, flags.size());
-        Assertions.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)));
+        Assert.assertEquals(2, flags.size());
+        Assert.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)));
 
         ItemStack itemStack4 = new ItemStackBuilder(Material.QUARTZ)
                 .withFlags(ItemFlag.HIDE_ATTRIBUTES)
                 .withFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)
                 .item();
         flags = Objects.requireNonNull(itemStack4.getItemMeta()).getItemFlags();
-        Assertions.assertEquals(2, flags.size());
-        Assertions.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)));
+        Assert.assertEquals(2, flags.size());
+        Assert.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_ENCHANTS)));
 
         ItemStack itemStack5 = new ItemStackBuilder(Material.QUARTZ)
                 .hideAllAttributes()
                 .item();
         flags = Objects.requireNonNull(itemStack5.getItemMeta()).getItemFlags();
-        Assertions.assertEquals(ItemFlag.values().length, flags.size());
-        Assertions.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.values())));
+        Assert.assertEquals(ItemFlag.values().length, flags.size());
+        Assert.assertTrue(flags.containsAll(Arrays.asList(ItemFlag.values())));
     }
 }

--- a/src/test/java/fr/zcraft/quartzlib/tools/mojang/MojangHeadTest.java
+++ b/src/test/java/fr/zcraft/quartzlib/tools/mojang/MojangHeadTest.java
@@ -7,28 +7,28 @@ import java.util.Objects;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 class MojangHeadTest extends MockedBukkitTest {
     @Test
-    void canCreateHeadItems() {
-        Assertions.assertEquals("MHF_Cake", MojangHead.CAKE.getHeadName());
+    public void canCreateHeadItems() {
+        Assert.assertEquals("MHF_Cake", MojangHead.CAKE.getHeadName());
         ItemStack item = MojangHead.CAKE.asItem();
 
-        Assertions.assertEquals(Material.PLAYER_HEAD, item.getType());
-        Assertions.assertEquals(1, item.getAmount());
-        Assertions.assertEquals("MHF_Cake", ((SkullMeta) Objects.requireNonNull(item.getItemMeta())).getOwner());
+        Assert.assertEquals(Material.PLAYER_HEAD, item.getType());
+        Assert.assertEquals(1, item.getAmount());
+        Assert.assertEquals("MHF_Cake", ((SkullMeta) Objects.requireNonNull(item.getItemMeta())).getOwner());
 
         ItemStack isbItem = MojangHead.CAKE.asItemBuilder().item();
 
-        Assertions.assertEquals(Material.PLAYER_HEAD, isbItem.getType());
-        Assertions.assertEquals(1, item.getAmount());
-        Assertions.assertEquals("MHF_Cake", ((SkullMeta) Objects.requireNonNull(isbItem.getItemMeta())).getOwner());
+        Assert.assertEquals(Material.PLAYER_HEAD, isbItem.getType());
+        Assert.assertEquals(1, item.getAmount());
+        Assert.assertEquals("MHF_Cake", ((SkullMeta) Objects.requireNonNull(isbItem.getItemMeta())).getOwner());
     }
 
     @Test
-    void headNamesMatch() {
+    public void headNamesMatch() {
         HashMap<MojangHead, String> headNames = new HashMap<>();
 
         headNames.put(MojangHead.ALEX, "MHF_Alex");
@@ -76,9 +76,9 @@ class MojangHeadTest extends MockedBukkitTest {
         headNames.put(MojangHead.EXCLAMATION, "MHF_Exclamation");
         headNames.put(MojangHead.QUESTION, "MHF_Question");
 
-        Assertions.assertEquals(headNames.size(), MojangHead.values().length);
-        Assertions.assertTrue(headNames.keySet().containsAll(Arrays.asList(MojangHead.values().clone())));
+        Assert.assertEquals(headNames.size(), MojangHead.values().length);
+        Assert.assertTrue(headNames.keySet().containsAll(Arrays.asList(MojangHead.values().clone())));
 
-        headNames.forEach((head, name) -> Assertions.assertEquals(name, head.getHeadName()));
+        headNames.forEach((head, name) -> Assert.assertEquals(name, head.getHeadName()));
     }
 }


### PR DESCRIPTION
- Added JUnit Vintage
- Migrated MockBukkit tests to JUnit 4 as MockBukkti does not support JUnit 5

---

All tests pass (including new ones) except:

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.007 s <<< FAILURE! - in fr.zcraft.quartzlib.core.QuartzLibTest
[ERROR] fr.zcraft.quartzlib.core.QuartzLibTest.getPluginTest  Time elapsed: 0.002 s  <<< ERROR!
java.lang.IllegalStateException: Assertion failed: QuartzLib is not correctly inizialized. Make sure QuartzLib.init() or QuartzLib.onLoad() is correctly called.
	at fr.zcraft.quartzlib.core.QuartzLibTest.getPluginTest(QuartzLibTest.java:12)
```

and

```
[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.269 s <<< FAILURE! - in fr.zcraft.quartzlib.tools.items.ItemStackBuilderTest
[ERROR] fr.zcraft.quartzlib.tools.items.ItemStackBuilderTest.canAddFlags  Time elapsed: 1.244 s  <<< FAILURE!
java.lang.AssertionError: expected:<1> but was:<0>
	at fr.zcraft.quartzlib.tools.items.ItemStackBuilderTest.canAddFlags(ItemStackBuilderTest.java:186)
```