### PR TITLE
Renamed back NBTType class

### DIFF
--- a/src/main/java/fr/zcraft/quartzlib/components/nbt/NBT.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/nbt/NBT.java
@@ -317,7 +317,7 @@ public abstract class NBT {
             return null;
         }
 
-        NbtType type = NbtType.fromClass(value.getClass());
+        NBTType type = NBTType.fromClass(value.getClass());
         return type.newTag(value);
     }
 
@@ -334,7 +334,7 @@ public abstract class NBT {
         if (nbtTag == null) {
             return null;
         }
-        NbtType type = NbtType.fromNmsNbtTag(nbtTag);
+        NBTType type = NBTType.fromNmsNbtTag(nbtTag);
 
         switch (type) {
             case TAG_COMPOUND:

--- a/src/main/java/fr/zcraft/quartzlib/components/nbt/NBTCompound.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/nbt/NBTCompound.java
@@ -67,7 +67,7 @@ public class NBTCompound implements Map<String, Object> {
         if (nativeNbtTag == null) {
             this.nmsNbtMap = new HashMap<>();
         } else {
-            this.nmsNbtMap = (Map<String, Object>) NbtType.TAG_COMPOUND.getData(nmsNbtTag);
+            this.nmsNbtMap = (Map<String, Object>) NBTType.TAG_COMPOUND.getData(nmsNbtTag);
         }
 
         this.parent = null;
@@ -92,10 +92,10 @@ public class NBTCompound implements Map<String, Object> {
         if (nmsNbtMap == null) {
             nmsNbtMap = new HashMap<>();
             if (nmsNbtTag != null) {
-                NbtType.TAG_COMPOUND.setData(nmsNbtTag, nmsNbtMap);
+                NBTType.TAG_COMPOUND.setData(nmsNbtTag, nmsNbtMap);
             } else {
-                nmsNbtTag = NbtType.TAG_COMPOUND.newTag(nmsNbtMap);
-                NbtType.TAG_LIST.setData(nmsNbtTag, nmsNbtTag);
+                nmsNbtTag = NBTType.TAG_COMPOUND.newTag(nmsNbtMap);
+                NBTType.TAG_LIST.setData(nmsNbtTag, nmsNbtTag);
 
                 if (parent != null && parentKey != null) {
                     if (parent instanceof NBTCompound) {

--- a/src/main/java/fr/zcraft/quartzlib/components/nbt/NBTList.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/nbt/NBTList.java
@@ -50,7 +50,7 @@ public class NBTList implements List<Object> {
     private final Object parentKey;
     List<Object> nmsNbtList;
     private Object nmsNbtTag;
-    private NbtType type = NbtType.TAG_END;
+    private NBTType type = NBTType.TAG_END;
 
     /**
      * Created a new empty NBT list.
@@ -63,7 +63,7 @@ public class NBTList implements List<Object> {
 
     @SuppressWarnings("unchecked")
     NBTList(Object nmsListTag) {
-        this(null, nmsListTag == null ? new ArrayList<>() : (List<Object>) NbtType.TAG_LIST.getData(nmsListTag));
+        this(null, nmsListTag == null ? new ArrayList<>() : (List<Object>) NBTType.TAG_LIST.getData(nmsListTag));
     }
 
     private NBTList(Object nmsListTag, List<Object> nmsNbtList) {
@@ -91,8 +91,8 @@ public class NBTList implements List<Object> {
 
     static void guessAndWriteTypeToNbtTagList(Object nmsNbtTag) {
         try {
-            final NbtType currentType = NbtType.fromId((byte) Reflection.getFieldValue(nmsNbtTag, "type"));
-            if (currentType.equals(NbtType.TAG_END)) {
+            final NBTType currentType = NBTType.fromId((byte) Reflection.getFieldValue(nmsNbtTag, "type"));
+            if (currentType.equals(NBTType.TAG_END)) {
                 // We retrieve the first element of the internal list and use it as
                 // the list type, if the list is not empty.
                 @SuppressWarnings("unchecked") final List<Object> internalNbtList =
@@ -100,7 +100,7 @@ public class NBTList implements List<Object> {
 
                 if (!internalNbtList.isEmpty()) {
                     Reflection.setFieldValue(nmsNbtTag, "type",
-                            (byte) NbtType.fromNmsNbtTag(internalNbtList.get(0)).getId());
+                            (byte) NBTType.fromNmsNbtTag(internalNbtList.get(0)).getId());
                 }
             }
         } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -114,11 +114,11 @@ public class NBTList implements List<Object> {
         if (nmsNbtList == null) {
             nmsNbtList = new ArrayList<>();
             if (nmsNbtTag != null) {
-                NbtType.TAG_LIST.setData(nmsNbtTag, nmsNbtList);
+                NBTType.TAG_LIST.setData(nmsNbtTag, nmsNbtList);
                 setTypeFromNbtTag();
             } else {
-                nmsNbtTag = NbtType.TAG_LIST.newTag(nmsNbtList);
-                NbtType.TAG_LIST.setData(nmsNbtTag, nmsNbtList);
+                nmsNbtTag = NBTType.TAG_LIST.newTag(nmsNbtList);
+                NBTType.TAG_LIST.setData(nmsNbtTag, nmsNbtList);
 
                 setTypeFromNbtList();
                 writeTypeToNbtTag();
@@ -139,7 +139,7 @@ public class NBTList implements List<Object> {
     private void setTypeFromNbtTag() {
         if (nmsNbtTag != null) {
             try {
-                this.type = NbtType.fromId((byte) Reflection.getFieldValue(nmsNbtTag, "type"));
+                this.type = NBTType.fromId((byte) Reflection.getFieldValue(nmsNbtTag, "type"));
             } catch (NoSuchFieldException | IllegalAccessException e) {
                 PluginLogger.error("Unable to retrieve NBTTagList's type."
                                 + " The type will be guessed next time an element is inserted into the list…", e);
@@ -149,7 +149,7 @@ public class NBTList implements List<Object> {
 
     private void setTypeFromNbtList() {
         if (nmsNbtList != null && !nmsNbtList.isEmpty()) {
-            setType(NbtType.fromNmsNbtTag(nmsNbtList.get(0)));
+            setType(NBTType.fromNmsNbtTag(nmsNbtList.get(0)));
         }
     }
 
@@ -165,19 +165,19 @@ public class NBTList implements List<Object> {
         }
     }
 
-    public NbtType getType() {
+    public NBTType getType() {
         return type;
     }
 
-    private void setType(NbtType type) {
+    private void setType(NBTType type) {
         this.type = type;
         writeTypeToNbtTag();
     }
 
     private void checkType(Object o) {
-        if (type == null || type.equals(NbtType.TAG_END)) {
+        if (type == null || type.equals(NBTType.TAG_END)) {
             try {
-                setType(NbtType.fromClass(o.getClass()));
+                setType(NBTType.fromClass(o.getClass()));
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Illegal type class in a NBT list: " + o.getClass(), e);
             }

--- a/src/main/java/fr/zcraft/quartzlib/components/nbt/NBTType.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/nbt/NBTType.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 
-enum NbtType {
+enum NBTType {
     TAG_END((byte) 0, null, Void.class),
     TAG_BYTE((byte) 1, "NBTTagByte", byte.class, Byte.class),
     TAG_SHORT((byte) 2, "NBTTagShort", short.class, Short.class),
@@ -56,14 +56,14 @@ enum NbtType {
     private final String nmsClassName;
     private Class nmsClass;
 
-    NbtType(byte id, String nmsClassName, Class... types) {
+    NBTType(byte id, String nmsClassName, Class... types) {
         this.id = id;
         this.types = types;
         this.nmsClassName = nmsClassName;
     }
 
-    public static NbtType fromId(byte id) {
-        for (NbtType type : NbtType.values()) {
+    public static NBTType fromId(byte id) {
+        for (NBTType type : NBTType.values()) {
             if (id == type.id) {
                 return type;
             }
@@ -72,7 +72,7 @@ enum NbtType {
         throw new IllegalArgumentException("Illegal type id: " + id);
     }
 
-    public static NbtType fromNmsNbtTag(Object nmsNbtTag) {
+    public static NBTType fromNmsNbtTag(Object nmsNbtTag) {
         try {
             return fromId((byte) Reflection.call(nmsNbtTag, "getTypeId"));
         } catch (Exception ex) {
@@ -80,8 +80,8 @@ enum NbtType {
         }
     }
 
-    public static NbtType fromClass(Class klass) {
-        for (NbtType type : NbtType.values()) {
+    public static NBTType fromClass(Class klass) {
+        for (NBTType type : NBTType.values()) {
             if (type.isAssignableFrom(klass)) {
                 return type;
             }


### PR DESCRIPTION
PR #59 renamed this class by accident.

He also renamed two classes in the test cases, but I have chosen to leave them as they are, as these names are actually better:

- `POParserTest` → `PoParserTest` (was incoherent with `PoTranslatorTest`);
- `YAMLTranslatorTest` → `YamlTranslatorTest`.