### PR TITLE
Refactor Glow effect, add an EventListener to prevent Glow objects from being disenchanted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ _Published one day_
 - All helpers that generate shaped recipes (2x2, 2x2 diagonal, etc.) now return `ShapedRecipe`s explicitely, since there
   is no way those recipes can be anything other than shaped, and hiding this detail is not useful at all.
 
+#### `GlowEffect`
+- :warning: This class is not an enchantment anymore and has been re-implemented. It is now a `QuartzComponent` that
+  needs to be enabled at startup in order to prevent items with a Glow effect to be used in a Grindstone.
+
 ## QuartzLib 0.0.2
 
 _Published on November 26th, 2020_

--- a/src/main/java/fr/zcraft/quartzlib/tools/items/GlowEffect.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/items/GlowEffect.java
@@ -30,15 +30,28 @@
 
 package fr.zcraft.quartzlib.tools.items;
 
+import fr.zcraft.quartzlib.core.QuartzComponent;
+import fr.zcraft.quartzlib.core.QuartzLib;
 import fr.zcraft.quartzlib.tools.PluginLogger;
 import java.lang.reflect.Field;
+import java.util.Map;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.enchantments.EnchantmentTarget;
-import org.bukkit.enchantments.EnchantmentWrapper;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A fake enchantment to add a glowing effect on any item.
@@ -47,13 +60,14 @@ import org.bukkit.inventory.meta.ItemMeta;
  *
  * @author Amaury Carrade
  */
-public class GlowEffect extends EnchantmentWrapper {
-    private static final int ENCHANTMENT_ID = 254;
-    private static final String ENCHANTMENT_NAME = "GlowEffect";
-    private static Enchantment glow;
+public class GlowEffect extends QuartzComponent {
+    private static final String ENCHANTMENT_NAME = "____gloweffect____";
+    @Nullable
+    private static Enchantment glowEnchantment = null;
 
-    protected GlowEffect(String id) {
-        super(id);
+    @Override
+    protected void onEnable() {
+        QuartzLib.registerEvents(new GlowEnchantEventListener());
     }
 
     /**
@@ -61,9 +75,15 @@ public class GlowEffect extends EnchantmentWrapper {
      *
      * @return an instance of the fake enchantment.
      */
-    private static Enchantment getGlow() {
-        if (glow != null) {
-            return glow;
+    private static @NotNull Enchantment getGlow() {
+        if (glowEnchantment != null) {
+            return glowEnchantment;
+        }
+
+        glowEnchantment = Enchantment.getByKey(getEnchantmentKey());
+
+        if (glowEnchantment != null) {
+            return glowEnchantment;
         }
 
         try {
@@ -76,24 +96,14 @@ public class GlowEffect extends EnchantmentWrapper {
             PluginLogger.error("Unable to re-enable enchantments registrations", e);
         }
 
-        try {
-            try {
-                glow = new GlowEffect("LURE");
-                Enchantment.registerEnchantment(glow);
-            } catch (NoSuchMethodError e) {
-                // 1.13+
+        glowEnchantment = new GlowEffectEnchantment();
+        Enchantment.registerEnchantment(glowEnchantment);
 
-            }
+        return glowEnchantment;
+    }
 
-        } catch (IllegalArgumentException e) {
-            // If the enchantment is already registered - happens on server
-            // reload
-            glow = Enchantment.getByName("LURE"); // getByID required - by
-            // name it doesn't work
-            // (returns null).
-        }
-
-        return glow;
+    private static NamespacedKey getEnchantmentKey() {
+        return new NamespacedKey(QuartzLib.getPlugin(), ENCHANTMENT_NAME);
     }
 
     /**
@@ -156,40 +166,108 @@ public class GlowEffect extends EnchantmentWrapper {
 
         Enchantment glow = getGlow();
         if (glow != null) {
-            return item.getEnchantmentLevel(glow) > 0;
+            // For some reason, item.containsEnchantment() doesn't work, but meta.hasEnchant() does
+            ItemMeta meta = item.getItemMeta();
+            if (meta != null) {
+                return meta.hasEnchant(glow);
+            }
+            return false;
         }
         return false;
     }
 
-    /* ** Enchantment properties overwritten ** */
+    private static class GlowEnchantEventListener implements Listener {
+        @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+        public void onInventoryClick(InventoryClickEvent event) {
+            if (event.getInventory().getType() != InventoryType.GRINDSTONE) {
+                return;
+            }
 
-    @Override
-    public boolean canEnchantItem(ItemStack item) {
-        return true;
+            if (event.getClick().isShiftClick() && hasGlow(event.getCurrentItem())) {
+                event.setResult(Event.Result.DENY);
+                return;
+            }
+
+            Inventory clickedInventory = event.getClickedInventory();
+            if (clickedInventory == null || clickedInventory.getType() != InventoryType.GRINDSTONE) {
+                return;
+            }
+
+            if (hasGlow(event.getCursor())) {
+                event.setResult(Event.Result.DENY);
+                return;
+            }
+
+            for (ItemStack item : clickedInventory) {
+                if (hasGlow(item)) {
+                    event.setResult(Event.Result.DENY);
+                    return;
+                }
+            }
+        }
+
+        @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+        public void onInventoryDrag(InventoryDragEvent event) {
+            if (event.getInventory().getType() != InventoryType.GRINDSTONE) {
+                return;
+            }
+
+            for (Map.Entry<Integer, ItemStack> entry : event.getNewItems().entrySet()) {
+                Inventory dragResult = event.getView().getInventory(entry.getKey());
+                if (dragResult != null && dragResult.getType() == InventoryType.GRINDSTONE) {
+                    if (hasGlow(entry.getValue())) {
+                        event.setResult(Event.Result.DENY);
+                        return;
+                    }
+                }
+            }
+        }
     }
 
-    @Override
-    public boolean conflictsWith(Enchantment other) {
-        return false;
-    }
+    private static class GlowEffectEnchantment extends Enchantment {
+        protected GlowEffectEnchantment() {
+            super(getEnchantmentKey());
+        }
 
-    @Override
-    public EnchantmentTarget getItemTarget() {
-        return null;
-    }
+        @Override
+        public boolean canEnchantItem(@NotNull ItemStack item) {
+            return true;
+        }
 
-    @Override
-    public int getMaxLevel() {
-        return 5;
-    }
+        @Override
+        public boolean conflictsWith(@NotNull Enchantment other) {
+            return false;
+        }
 
-    @Override
-    public String getName() {
-        return ENCHANTMENT_NAME;
-    }
+        @Override
+        public @NotNull EnchantmentTarget getItemTarget() {
+            return EnchantmentTarget.ALL;
+        }
 
-    @Override
-    public int getStartLevel() {
-        return 1;
+        @Override
+        public boolean isTreasure() {
+            return false;
+        }
+
+        @Override
+        public boolean isCursed() {
+            return false;
+        }
+
+        @Override
+        public int getMaxLevel() {
+            return 1;
+        }
+
+        @Override
+        public @NotNull String getName() {
+            return ENCHANTMENT_NAME;
+        }
+
+        @Override
+        public int getStartLevel() {
+            return 1;
+        }
+
     }
 }

--- a/src/main/java/fr/zcraft/quartzlib/tools/items/GlowEffect.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/items/GlowEffect.java
@@ -54,9 +54,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A fake enchantment to add a glowing effect on any item.
+ * Utilities creating a fake enchantment to add a glowing effect on any item.
  *
- * <strong>Only work with 1.12 and before.</strong>
+ * <p><b>NOTE:</b> this component needs to be loaded at startup, otherwise it will still works but items using
+ * created using this effect may be used in a grindstone to cheat out experience to players.</p>
  *
  * @author Amaury Carrade
  */
@@ -75,7 +76,7 @@ public class GlowEffect extends QuartzComponent {
      *
      * @return an instance of the fake enchantment.
      */
-    private static @NotNull Enchantment getGlow() {
+    private static Enchantment getGlow() {
         if (glowEnchantment != null) {
             return glowEnchantment;
         }
@@ -108,8 +109,6 @@ public class GlowEffect extends QuartzComponent {
 
     /**
      * Adds a glowing effect to the given item stack.
-     * <p>Warning: this effect is a bit unstable: it will be thrown away if the
-     * item's meta is updated. So add it at the end.</p>
      *
      * @param item The item.
      */

--- a/src/main/java/fr/zcraft/quartzlib/tools/items/GlowEffect.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/items/GlowEffect.java
@@ -33,6 +33,7 @@ package fr.zcraft.quartzlib.tools.items;
 import fr.zcraft.quartzlib.core.QuartzComponent;
 import fr.zcraft.quartzlib.core.QuartzLib;
 import fr.zcraft.quartzlib.tools.PluginLogger;
+import fr.zcraft.quartzlib.tools.reflection.Reflection;
 import java.lang.reflect.Field;
 import java.util.Map;
 import org.bukkit.Material;
@@ -69,6 +70,7 @@ public class GlowEffect extends QuartzComponent {
     @Override
     protected void onEnable() {
         QuartzLib.registerEvents(new GlowEnchantEventListener());
+        getGlow();
     }
 
     /**
@@ -90,9 +92,7 @@ public class GlowEffect extends QuartzComponent {
         try {
             // We change this to force Bukkit to accept a new enchantment.
             // Thanks to Cybermaxke on BukkitDev.
-            Field acceptingNewField = Enchantment.class.getDeclaredField("acceptingNew");
-            acceptingNewField.setAccessible(true);
-            acceptingNewField.set(null, true);
+            Reflection.setFieldValue(Enchantment.class, null, "acceptingNew", true);
         } catch (Exception e) {
             PluginLogger.error("Unable to re-enable enchantments registrations", e);
         }
@@ -121,18 +121,6 @@ public class GlowEffect extends QuartzComponent {
 
         if (glow != null) {
             item.addEnchantment(glow, 1);
-        } else {
-            //from https://github.com/zDevelopers/QuartzLib/pull/21/files#diff-cd248f55f1484c684edc6fa27c585899L167-R44
-            if (item.getItemMeta().hasEnchants()) {
-                return;
-            }
-
-            final Enchantment fakeGlow =
-                    item.getType() != Material.FISHING_ROD ? Enchantment.LURE : Enchantment.ARROW_DAMAGE;
-            final ItemMeta im = item.getItemMeta();
-            im.addEnchant(fakeGlow, 1, true);
-            im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-            item.setItemMeta(im);
         }
     }
 

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/Toast.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/Toast.java
@@ -51,6 +51,6 @@ public class Toast {
     }
 
     public enum CookingStatus {
-        COOKED, NOT_COOKED
+        COOKED, IN_OVEN, NOT_COOKED
     }
 }

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/ToastExplorer.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/ToastExplorer.java
@@ -33,6 +33,7 @@ package fr.zcraft.ztoaster;
 import fr.zcraft.quartzlib.components.gui.ExplorerGui;
 import fr.zcraft.quartzlib.components.gui.GuiUtils;
 import fr.zcraft.quartzlib.components.i18n.I;
+import fr.zcraft.quartzlib.tools.items.ItemStackBuilder;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -43,7 +44,7 @@ public class ToastExplorer extends ExplorerGui<Toast> {
 
         setData(Toaster.getToasts());
 
-        //DO NOT TOUCH THE TOASTS !
+        // DO NOT TOUCH THE TOASTS !
         setMode(ExplorerGui.Mode.READONLY);
     }
 
@@ -53,8 +54,10 @@ public class ToastExplorer extends ExplorerGui<Toast> {
             return GuiUtils.makeItem(Material.COOKED_PORKCHOP,
                     I.t(getPlayerLocale(), "{white}Cooked toast #{0}", toast.getToastId()));
         } else { // Title of the raw toast item in GUI
-            return GuiUtils.makeItem(Material.PORKCHOP,
-                    I.t(getPlayerLocale(), "{white}Raw toast #{0}", toast.getToastId()));
+            return new ItemStackBuilder(Material.PORKCHOP)
+                    .title(I.tl(getPlayerLocale(), "{white}Raw toast #{0}", toast.getToastId()))
+                    .glow(toast.getStatus() == Toast.CookingStatus.IN_OVEN)
+                    .item();
         }
     }
 }

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/Toaster.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/Toaster.java
@@ -37,6 +37,7 @@ import fr.zcraft.quartzlib.components.scoreboard.Sidebar;
 import fr.zcraft.quartzlib.components.scoreboard.SidebarScoreboard;
 import fr.zcraft.quartzlib.core.QuartzPlugin;
 import fr.zcraft.quartzlib.tools.PluginLogger;
+import fr.zcraft.quartzlib.tools.items.GlowEffect;
 import fr.zcraft.ztoaster.commands.AddCommand;
 import fr.zcraft.ztoaster.commands.ListCommand;
 import fr.zcraft.ztoaster.commands.OpenCommand;
@@ -108,7 +109,7 @@ public class Toaster extends QuartzPlugin implements Listener {
         toasts = new ArrayList<>();
         toastCounter = 0;
 
-        loadComponents(Gui.class, Commands.class, ToasterWorker.class, SidebarScoreboard.class, I18n.class);
+        loadComponents(Gui.class, Commands.class, ToasterWorker.class, SidebarScoreboard.class, I18n.class, GlowEffect.class);
 
         Commands.register("toaster", AddCommand.class, OpenCommand.class, ListCommand.class);
 

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/ToasterSidebar.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/ToasterSidebar.java
@@ -42,7 +42,7 @@ import org.bukkit.entity.Player;
 
 public class ToasterSidebar extends Sidebar {
     private int toastsCount = 0;
-    private int insideTheToaster = 0;
+    private long insideTheToaster = 0;
 
     public ToasterSidebar() {
         setAsync(true);
@@ -57,25 +57,22 @@ public class ToasterSidebar extends Sidebar {
 
         toastsCount = toasts.length;
 
-        insideTheToaster = 0;
-        for (Toast toast : toasts) {
-            if (toast.getStatus() == Toast.CookingStatus.NOT_COOKED) {
-                insideTheToaster++;
-            }
-        }
+        insideTheToaster = Arrays.stream(toasts)
+                .filter(toast -> toast.getStatus() != Toast.CookingStatus.COOKED)
+                .count();
     }
 
     @Override
     public List<String> getContent(Player player) {
         Locale playerLocale = I18n.getPlayerLocale(player);
         return Arrays.asList(
-                I.t(playerLocale, "{darkgreen}{bold}Cook"),
+                I.tl(playerLocale, "{darkgreen}{bold}Cook"),
                 player.getDisplayName(),
                 "",
-                I.t(playerLocale, "{yellow}{bold}Inside the toaster"),
+                I.tl(playerLocale, "{yellow}{bold}Inside the toaster"),
                 insideTheToaster + "",
                 "",
-                I.t(playerLocale, "{gold}{bold}Cooked"),
+                I.tl(playerLocale, "{gold}{bold}Cooked"),
                 (toastsCount - insideTheToaster) + ""
         );
     }
@@ -83,9 +80,9 @@ public class ToasterSidebar extends Sidebar {
     @Override
     public String getTitle(Player player) {
         if (insideTheToaster > 0) {
-            return I.t(I18n.getPlayerLocale(player), "{red}{bold}♨ Toaster ♨");
+            return I.tl(I18n.getPlayerLocale(player), "{red}{bold}♨ Toaster ♨");
         } else {
-            return I.t(I18n.getPlayerLocale(player), "{blue}Toaster");
+            return I.tl(I18n.getPlayerLocale(player), "{blue}Toaster");
         }
     }
 }

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/ToasterWorker.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/ToasterWorker.java
@@ -77,6 +77,7 @@ public class ToasterWorker extends Worker {
             public Object run() throws Throwable {
                 PluginLogger.info("Cooking toast #{0} ...", toastId);
 
+                newToast.setStatus(Toast.CookingStatus.IN_OVEN);
                 Thread.sleep(TOAST_COOKING_TIME);
 
                 PluginLogger.info("Toast #{0} cooked !", toastId);

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/commands/AddCommand.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/commands/AddCommand.java
@@ -47,14 +47,14 @@ public class AddCommand extends Command {
 
         if (args.length == 0) {
             Toast toast = ToasterWorker.addToast(cook);
-            cook.sendMessage(I.t("Toast {0} added.", toast.getToastId()));
+            cook.sendMessage(I.tl(cook, "Toast {0} added.", toast.getToastId()));
         } else {
             int toastCount = getIntegerParameter(0);
             for (int i = toastCount; i-- > 0; ) {
                 ToasterWorker.addToast(cook);
             }
 
-            cook.sendMessage(I.tn("One toast added.", "{0} toasts added.", toastCount, toastCount));
+            cook.sendMessage(I.tln(cook, "One toast added.", "{0} toasts added.", toastCount, toastCount));
         }
     }
 }

--- a/ztoaster/src/main/java/fr/zcraft/ztoaster/commands/ListCommand.java
+++ b/ztoaster/src/main/java/fr/zcraft/ztoaster/commands/ListCommand.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-@CommandInfo(name = "list", usageParameters = "[cooked|not_cooked]")
+@CommandInfo(name = "list", usageParameters = "[cooked|in_oven|not_cooked]")
 public class ListCommand extends Command {
     @Override
     protected void run() throws CommandException {
@@ -63,7 +63,7 @@ public class ListCommand extends Command {
     private void showToasts(Collection<Toast> toasts) {
         if (toasts.isEmpty()) {
             // Output of the command /toaster list, without toasts.
-            info(I.t("There are no toasts here ..."));
+            info(I.t("There are no toasts here..."));
         }
 
         for (Toast toast : toasts) {


### PR DESCRIPTION
This changes `GlowEffect` from being an `Enchantment` to being a `QuartzComponent`, as it needs to register an `EventListener` at startup to prevent glowed-up items to be used in a Grindstone.

This fixes #24.
This fixes #25.