### PR TITLE
Fixed the NoSuchMethodException

### DIFF
--- a/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
@@ -521,9 +521,10 @@ public final class MessageSender {
 
                     if (nmsMessageType != null) {
                         try {
-                            //Packet changed in 1.16+ an UUID is needed
-                            //An UUID with both longs set to 0 will always display 
-                            //(even if the player has turn the option disableChat on)
+                            // 1.16.1+ chat packets constructor require an UUID. To send
+                            // system messages, we need to give a null UUID (else the message
+                            // will be filtered if the player disabled chat messages on their
+                            // client).
                             chatPacket = packetPlayOutChatClass
                                     .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum, UUID.class)
                                     .newInstance(componentText, nmsMessageType, new UUID(0, 0));

--- a/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
@@ -520,9 +520,17 @@ public final class MessageSender {
                     final Enum<?> nmsMessageType = type.getMessagePositionEnumValue();
 
                     if (nmsMessageType != null) {
-                        chatPacket = packetPlayOutChatClass
-                                .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum)
-                                .newInstance(componentText, nmsMessageType);
+                        try {
+                            chatPacket = packetPlayOutChatClass
+                                    .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum)
+                                    .newInstance(componentText, nmsMessageType);
+                        } catch (NoSuchMethodException ex) {
+                            //Packet changed in 1.16+ an UUID is needed
+                            chatPacket = packetPlayOutChatClass
+                                    .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum, UUID.class)
+                                    .newInstance(componentText, nmsMessageType, new UUID(0, 0));
+
+                        }
                     } else {
                         chatPacket = packetPlayOutChatClass
                                 .getConstructor(iChatBaseComponentClass, byte.class)

--- a/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
@@ -522,6 +522,7 @@ public final class MessageSender {
                     if (nmsMessageType != null) {
                         try {
                             //Packet changed in 1.16+ an UUID is needed
+                            //An UUID with both longs set to 0 will always display (even if the player has turn the option disableChat on)
                             chatPacket = packetPlayOutChatClass
                                     .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum, UUID.class)
                                     .newInstance(componentText, nmsMessageType, new UUID(0, 0));

--- a/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
@@ -522,7 +522,8 @@ public final class MessageSender {
                     if (nmsMessageType != null) {
                         try {
                             //Packet changed in 1.16+ an UUID is needed
-                            //An UUID with both longs set to 0 will always display (even if the player has turn the option disableChat on)
+                            //An UUID with both longs set to 0 will always display 
+                            //(even if the player has turn the option disableChat on)
                             chatPacket = packetPlayOutChatClass
                                     .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum, UUID.class)
                                     .newInstance(componentText, nmsMessageType, new UUID(0, 0));

--- a/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
+++ b/src/main/java/fr/zcraft/quartzlib/tools/text/MessageSender.java
@@ -521,15 +521,15 @@ public final class MessageSender {
 
                     if (nmsMessageType != null) {
                         try {
-                            chatPacket = packetPlayOutChatClass
-                                    .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum)
-                                    .newInstance(componentText, nmsMessageType);
-                        } catch (NoSuchMethodException ex) {
                             //Packet changed in 1.16+ an UUID is needed
                             chatPacket = packetPlayOutChatClass
                                     .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum, UUID.class)
                                     .newInstance(componentText, nmsMessageType, new UUID(0, 0));
 
+                        } catch (NoSuchMethodException ex) {
+                            chatPacket = packetPlayOutChatClass
+                                    .getConstructor(iChatBaseComponentClass, chatMessageTypeEnum)
+                                    .newInstance(componentText, nmsMessageType);
                         }
                     } else {
                         chatPacket = packetPlayOutChatClass


### PR DESCRIPTION
https://wiki.vg/Protocol#Chat_Message_.28clientbound.29 has changed in 1.16 and now need an UUID argument. Setting both longs to 0 will always display the message regardless of the setting. Tested in 1.15.2 and 1.16.5 both versions work

Closes zDevelopers/ImageOnMap#160