### PR TITLE
Fixed plural rules computation on Java 15+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
-name: Build & Test
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 jobs:
   build:
     name: Test on Java ${{ matrix.java }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,17 @@ name: Build & Test
 on: [push, pull_request]
 jobs:
   build:
+    name: Test on Java ${{ matrix.java }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 9, 10, 11, 12, 13, 14, 15]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/quartzlib/pom.xml
+++ b/quartzlib/pom.xml
@@ -111,6 +111,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>20.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+            <version>20.3.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/quartzlib/pom.xml
+++ b/quartzlib/pom.xml
@@ -94,6 +94,7 @@
             <artifactId>bukkit</artifactId>
             <version>1.15-R0.1-SNAPSHOT</version>
         </dependency>
+
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
@@ -115,6 +116,7 @@
             <artifactId>js</artifactId>
             <version>20.3.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js-scriptengine</artifactId>

--- a/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/POFile.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/POFile.java
@@ -64,6 +64,7 @@ public class POFile {
 
     private Integer pluralCount = 2;
     private String pluralFormScript = "";
+    private PluralForms pluralForms = null;
 
 
     /**
@@ -303,6 +304,7 @@ public class POFile {
                             if (pluralFormScript.contains("=")) {
                                 pluralFormScript = pluralFormScript.split("=")[1];
                             }
+
                         } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
                             // Well, invalid.
                         }
@@ -312,6 +314,8 @@ public class POFile {
                 }
             }
         }
+
+        pluralForms = new PluralForms(pluralCount, pluralFormScript);
     }
 
     /**
@@ -360,6 +364,23 @@ public class POFile {
      */
     public String getPluralFormScript() {
         return pluralFormScript;
+    }
+
+    /**
+     * For a given number, compute the plural index to use for the locale of this file.
+     *
+     * <p>Some plural scripts are very commons. For them, we hardcode native functions.
+     * We then do not depend on a JavaScript engine, and it's order of magnitude faster.
+     * If you can use them, it's always better.
+     *
+     * <p>This method can only work correctly with Plural-Forms listed at:
+     * http://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html#Plural-forms
+     *
+     * @param count The count to compute plural for.
+     * @return The plural index.
+     */
+    public int computePluralForm(long count) {
+        return pluralForms.computePluralForm(count);
     }
 
 

--- a/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/POFile.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/POFile.java
@@ -378,8 +378,14 @@ public class POFile {
      *
      * @param count The count to compute plural for.
      * @return The plural index.
+     * @throws IllegalStateException if the method is called before {@link #parse()}.
      */
     public int computePluralForm(long count) {
+        // File not parsed yet
+        if (pluralForms == null) {
+            throw new IllegalStateException("Cannot compute plural form: the file is not parsed. Call parse() first.");
+        }
+
         return pluralForms.computePluralForm(count);
     }
 

--- a/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
@@ -94,7 +94,7 @@ public class PluralForms {
     }
 
     private Function<Long, Integer> computeFormsFunction() {
-        if (formsScript == null) {
+        if (formsScript == null || formsScript.isEmpty()) {
             return formsFunctionFallback();
         }
 

--- a/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
@@ -78,7 +78,7 @@ public class PluralForms {
      */
     public PluralForms(int formsCount, @Nullable String formsScript) {
         this.formsCount = formsCount;
-        this.formsScript = formsScript;
+        this.formsScript = formsScript.trim();
 
         this.formsFunction = computeFormsFunction();
     }
@@ -264,6 +264,14 @@ public class PluralForms {
      * @return a Function to compute the plural index from the given count.
      */
     private Function<Long, Integer> formsFunctionFallback() {
+        PluginLogger.warning(
+                  "Unknown plural rule “{0}”; without JavaScript engine available, we'll fallback to English "
+                + "pluralization rules. If you want your language's plural rule supported without JavaScript "
+                + "engine, please open an issue with your language and its plural rules at "
+                + "https://github.com/zDevelopers/QuartzLib/issues.",
+                formsScript
+        );
+
         return FORMS_FUNCTION_FALLBACK;
     }
 }

--- a/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
@@ -1,0 +1,269 @@
+/*
+ * Plugin UHCReloaded : Alliances
+ *
+ * Copyright ou © ou Copr. Amaury Carrade (2016)
+ * Idées et réflexions : Alexandre Prokopowicz, Amaury Carrade, "Vayan".
+ *
+ * Ce logiciel est régi par la licence CeCILL soumise au droit français et
+ * respectant les principes de diffusion des logiciels libres. Vous pouvez
+ * utiliser, modifier et/ou redistribuer ce programme sous les conditions
+ * de la licence CeCILL telle que diffusée par le CEA, le CNRS et l'INRIA
+ * sur le site "http://www.cecill.info".
+ *
+ * En contrepartie de l'accessibilité au code source et des droits de copie,
+ * de modification et de redistribution accordés par cette licence, il n'est
+ * offert aux utilisateurs qu'une garantie limitée.  Pour les mêmes raisons,
+ * seule une responsabilité restreinte pèse sur l'auteur du programme,  le
+ * titulaire des droits patrimoniaux et les concédants successifs.
+ *
+ * A cet égard  l'attention de l'utilisateur est attirée sur les risques
+ * associés au chargement,  à l'utilisation,  à la modification et/ou au
+ * développement et à la reproduction du logiciel par l'utilisateur étant
+ * donné sa spécificité de logiciel libre, qui peut le rendre complexe à
+ * manipuler et qui le réserve donc à des développeurs et des professionnels
+ * avertis possédant  des  connaissances  informatiques approfondies.  Les
+ * utilisateurs sont donc invités à charger  et  tester  l'adéquation  du
+ * logiciel à leurs besoins dans des conditions permettant d'assurer la
+ * sécurité de leurs systèmes et ou de leurs données et, plus généralement,
+ * à l'utiliser et l'exploiter dans les mêmes conditions de sécurité.
+ *
+ * Le fait que vous puissiez accéder à cet en-tête signifie que vous avez
+ * pris connaissance de la licence CeCILL, et que vous en avez accepté les
+ * termes.
+ */
+
+package fr.zcraft.quartzlib.components.i18n.translators.gettext;
+
+import fr.zcraft.quartzlib.tools.PluginLogger;
+import java.util.Locale;
+import java.util.function.Function;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PluralForms {
+    /**
+     * The default plural forms function when we cannot do anything else. It's the English plural rule.
+     */
+    private static final Function<Long, Integer> FORMS_FUNCTION_FALLBACK = n -> n != 1 ? 1 : 0;
+
+    /**
+     * The number of plural forms for this script.
+     */
+    private final int formsCount;
+
+    /**
+     * The form script, as written in the PO/MO file.
+     */
+    @NotNull
+    private final String formsScript;
+
+    /**
+     * A function to call to compute the correct plural form
+     * from a count.
+     */
+    private final Function<Long, Integer> formsFunction;
+
+    /**
+     * Constructs a new Gettext plural form.
+     *
+     * <p>The script will be matched against a database of known script. If one match, it will be implemented in
+     * pure Java for better performances. Else, we'll fallback on a JavaScript Engine to do the work. If no
+     * engine can be loaded, we'll fallback on hardcoded English rules.
+     *
+     * @param formsCount  The number of plural forms.
+     * @param formsScript The raw script (without “plural=” prefix).
+     */
+    public PluralForms(int formsCount, @Nullable String formsScript) {
+        this.formsCount = formsCount;
+        this.formsScript = formsScript;
+
+        this.formsFunction = computeFormsFunction();
+    }
+
+    public int computePluralForm(long count) {
+        final int index = this.formsFunction.apply(count);
+
+        if (index < 0 || index > formsCount) {
+            return 0;
+        } else {
+            return index;
+        }
+    }
+
+    private Function<Long, Integer> computeFormsFunction() {
+        if (formsScript == null) {
+            return formsFunctionFallback();
+        }
+
+        // We first try if this script is known
+        Function<Long, Integer> function = formsFunctionFromKnownScripts();
+
+        // Else we try two JS engines, and fallback to English rules.
+        if (function == null) {
+            function = formsFunctionFromNashorn();
+        }
+        if (function == null) {
+            function = formsFunctionFromGraalVM();
+        }
+        if (function == null) {
+            function = formsFunctionFallback();
+        }
+
+        return function;
+    }
+
+    private String normalizeFormsScript(final String script) {
+        return script.toLowerCase(Locale.ROOT).replace(" ", "").trim();
+    }
+
+    /**
+     * Some plural scripts are very commons. For them, we hardcode native functions.
+     * We then do not depend on a JavaScript engine, and it's order of magnitude faster.
+     *
+     * <p>This evaluate method can only work correctly with Plural-Forms listed at:
+     * http://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html#Plural-forms
+     *
+     * @return a Function to compute the plural index from the given count.
+     */
+    private Function<Long, Integer> formsFunctionFromKnownScripts() {
+        switch (normalizeFormsScript(formsScript)) {
+            // Only one form
+            // Japanese, Vietnamese, Korean, Thai
+            case "0":
+                return n -> 0;
+
+            // Two forms, singular used for one only
+            // English, German, Dutch, Swedish, Danish, Norwegian, Faroese, Spanish, Portuguese, Italian,
+            // Greek, Bulgarian, Finnish, Estonian, Hebrew, ahasa Indonesian, Esperanto, Hungarian, Turkish
+            case "n!=1":
+                return n -> n != 1 ? 1 : 0;
+
+            case "n!=0":
+                return n -> n != 0 ? 1 : 0;
+
+            // Two forms, singular used for zero and one
+            // Brazilian Portuguese, French
+            case "n>0":
+                return n -> n > 0 ? 1 : 0;
+
+            case "n>1":
+                return n -> n > 1 ? 1 : 0;
+
+            // Three forms, special case for zero
+            // Latvian
+            case "n%10==1&&n%100!=11?0:n!=0?1:2":
+                return n -> n % 10 == 1 && n % 100 != 11 ? 0 : (n != 0 ? 1 : 2);
+
+            // Three forms, special cases for one and two
+            // Gaeilge (Irish)
+            case "n==1?0:n==2?1:2":
+                return n -> n == 1 ? 0 : (n == 2 ? 1 : 2);
+
+            // Three forms, special case for numbers ending in 00 or [2-9][0-9]
+            // Romanian
+            case "n==1?0:(n==0||(n%100>0&&n%100<20))?1:2":
+                return n -> n == 1 ? 0 : ((n == 0 || (n % 100 > 0 && n % 100 < 20)) ? 1 : 2);
+
+            // Three forms, special case for numbers ending in 1[2-9]
+            // Lithuanian
+            case "n%10==1&&n%100!=11?0:n%10>=2&&(n%100<10||n%100>=20)?1:2":
+                return n -> n % 10 == 1 && n % 100 != 11 ? 0 : (n % 10 >= 2 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
+
+            // Three forms, special cases for numbers ending in 1 and 2, 3, 4, except those ending in 1[1-4]
+            // Russian, Ukrainian, Belarusian, Serbian, Croatian
+            case "n%10==1&&n%100!=11?0:n%10>=2&&n%10<=4&&(n%100<10||n%100>=20)?1:2":
+                return n -> n % 10 == 1 && n % 100 != 11 ? 0 :
+                        (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
+
+            // Three forms, special cases for 1 and 2, 3, 4
+            // Czech, Slovak
+            case "(n==1)?0:(n>=2&&n<=4)?1:2":
+            case "n==1?0:(n>=2&&n<=4)?1:2":
+            case "n==1?0:n>=2&&n<=4?1:2":
+                return n -> n == 1 ? 0 : ((n >= 2 && n <= 4) ? 1 : 2);
+
+            // Three forms, special case for one and some numbers ending in 2, 3, or 4
+            // Polish
+            case "n==1?0:n%10>=2&&n%10<=4&&(n%100<10||n%100>=20)?1:2":
+                return n -> n == 1 ? 0 : (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20) ? 1 : 2);
+
+            // Four forms, special case for one and all numbers ending in 02, 03, or 04
+            // Slovenian
+            case "n%100==1?0:n%100==2?1:n%100==3||n%100==4?2:3":
+                return n -> n % 100 == 1 ? 0 : (n % 100 == 2 ? 1 : (n % 100 == 3 || n % 100 == 4 ? 2 : 3));
+
+            // Six forms, special cases for one, two, all numbers ending in 02, 03, … 10, all numbers ending in 11 … 99,
+            // and others
+            // Arabic
+            case "n==0?0:n==1?1:n==2?2:n%100>=3&&n%100<=10?3:n%100>=11?4:5":
+                return n -> n == 0 ? 0 :
+                        (n == 1 ? 1 : (n == 2 ? 2 : (n % 100 >= 3 && n % 100 <= 10 ? 3 : (n % 100 >= 11 ? 4 : 5))));
+
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * If the script is non-standard, we fallback on the buiilt-in Nashorn (available before Java 15).
+     *
+     * @return a Function to compute the plural index from the given count.
+     */
+    private Function<Long, Integer> formsFunctionFromNashorn() {
+        return formsFunctionFromJSEngine("JavaScript");
+    }
+
+    /**
+     * In Java 15+, we fallback on GraalVM.
+     *
+     * @return a Function to compute the plural index from the given count.
+     */
+    private Function<Long, Integer> formsFunctionFromGraalVM() {
+        return formsFunctionFromJSEngine("graal.js");
+    }
+
+    /**
+     * Generic computation from a JS engine.
+     *
+     * <p>The official documentation mentions that the plural determination script is in C format, but
+     * the JavaScript format is the same for these scripts (containing only basic mathematics and
+     * ternary operators), excepted for the booleans, but this case is handled manually.
+     *
+     * @return a Function to compute the plural index from the given count.
+     */
+    private Function<Long, Integer> formsFunctionFromJSEngine(final String engine) {
+        final ScriptEngine scriptEngine = new ScriptEngineManager().getEngineByName(engine);
+        if (scriptEngine == null) {
+            return null;
+        }
+
+        return n -> {
+            try {
+                scriptEngine.put("n", n);
+                Object rawPluralIndex = scriptEngine.eval(formsScript);
+
+                // If the index is a boolean, as some po files use the C handling of booleans, we convert them
+                // into the appropriate numbers.
+                // Else, we try to convert the output to an integer.
+                return rawPluralIndex instanceof Boolean ? (((Boolean) rawPluralIndex) ? 1 : 0) :
+                        (rawPluralIndex instanceof Number ? ((Number) rawPluralIndex).intValue() :
+                                Integer.valueOf(rawPluralIndex.toString()));
+            } catch (ScriptException | NumberFormatException e) {
+                PluginLogger.error("Invalid plural forms script “{1}”", e, formsScript);
+                return 0;
+            }
+        };
+    }
+
+    /**
+     * If nothing work, we fallback on hardcoded English rules.
+     *
+     * @return a Function to compute the plural index from the given count.
+     */
+    private Function<Long, Integer> formsFunctionFallback() {
+        return FORMS_FUNCTION_FALLBACK;
+    }
+}

--- a/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
+++ b/src/main/java/fr/zcraft/quartzlib/components/i18n/translators/gettext/PluralForms.java
@@ -266,7 +266,7 @@ public class PluralForms {
     private Function<Long, Integer> formsFunctionFallback() {
         PluginLogger.warning(
                   "Unknown plural rule “{0}”; without JavaScript engine available, we'll fallback to English "
-                + "pluralization rules. If you want your language's plural rule supported without JavaScript "
+                + "pluralization rules. If you want your language's plural rules supported without JavaScript "
                 + "engine, please open an issue with your language and its plural rules at "
                 + "https://github.com/zDevelopers/QuartzLib/issues.",
                 formsScript


### PR DESCRIPTION
This PR changes the following:

- We now try to load the GraalVM engine too, for Java 15+.
- We no longer crash if an engine is not available. We'll use English rules as a fallback.
- Before even loading any JS engine, we try to match the plural rules against a list of known rules implemented in pure Java.